### PR TITLE
Fix promotion rule spree select2

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/spree-select2.js
+++ b/backend/app/assets/javascripts/spree/backend/spree-select2.js
@@ -1,11 +1,17 @@
 //= require select2
-jQuery(function($) {
-  // Make select beautiful
-  $('select.select2').select2({
+$.fn.spreeSelect2 = function () {
+  'use strict';
+
+  this.select2({
     allowClear: true,
     dropdownAutoWidth: true,
     minimumResultsForSearch: 8
-  });
+  })
+}
+
+jQuery(function($) {
+  // Make select beautiful
+  $('select.select2').spreeSelect2();
 
   function format_taxons(taxon) {
     new_taxon = taxon.text.replace('->', '<i class="fa fa-arrow-right">')

--- a/backend/app/views/spree/admin/promotion_actions/create.js.erb
+++ b/backend/app/views/spree/admin/promotion_actions/create.js.erb
@@ -3,7 +3,7 @@ $('#actions .no-objects-found').hide();
 $(document).ready(function(){
   $(".variant_autocomplete").variantAutocomplete();
   //enable select2 functions for recently added box
-  $('.type-select.select2').last().select2();
+  $('.type-select.select2').last().spreeSelect2();
 });
 initProductActions();
 

--- a/backend/app/views/spree/admin/promotion_rules/create.js.erb
+++ b/backend/app/views/spree/admin/promotion_rules/create.js.erb
@@ -3,6 +3,7 @@ $('#rules .no-objects-found').hide();
 
 $('.product_picker').productAutocomplete();
 $('.user_picker').userAutocomplete();
+$('select.select2').spreeSelect2();
 
 $('#promotion_rule_type').html('<%= escape_javascript options_for_promotion_rule_types(@promotion) %>');
 $('#promotion_rule_type').select2();


### PR DESCRIPTION
@kennyadsl @mtylty @aleph1ow @RitaD This is just an idea, all around the code sometimes `select2` is called without options, this cause some incongruence, for example promotion actions are added with ajax, before these changes the first time the select2 is created without options but if a user reload the page it's created with options.

I've also fixed a small bug that don't initialize select2 inputs when a user add a promotion rules.