### PR TITLE
Fix promotion rule select 2

### DIFF
--- a/backend/app/views/spree/admin/promotion_rules/create.js.erb
+++ b/backend/app/views/spree/admin/promotion_rules/create.js.erb
@@ -7,4 +7,5 @@ $('.taxon_picker').taxonAutocomplete();
 
 $('#promotion_rule_type').html('<%= escape_javascript options_for_promotion_rule_types(@promotion) %>');
 $('#promotion_rule_type').select2();
+$('#rules select.select2').select2();
 


### PR DESCRIPTION
@mtylty @kennyadsl When a user add a promotion rule the select2 looks like:

![schermata 2016-10-06 alle 18 28 23](https://cloud.githubusercontent.com/assets/308848/19161083/b14549ea-8bf2-11e6-9006-28f95754bc97.png)

after the fix it looks like:

![schermata 2016-10-06 alle 18 29 04](https://cloud.githubusercontent.com/assets/308848/19161117/c93bc18c-8bf2-11e6-906c-1e6053e70a85.png)

