### PR TITLE
Fulfilment changer uncorrectly restocking and unstocking items

### DIFF
--- a/core/app/models/spree/fulfilment_changer.rb
+++ b/core/app/models/spree/fulfilment_changer.rb
@@ -44,6 +44,7 @@ module Spree
       desired_shipment.save! if desired_shipment.new_record?
 
       new_on_hand_quantity = [desired_shipment.stock_location.count_on_hand(variant), quantity].min
+      unstock_quantity = desired_shipment.stock_location.backorderable?(variant) ? quantity : new_on_hand_quantity
 
       ActiveRecord::Base.transaction do
         if handle_stock_counts?
@@ -53,7 +54,7 @@ module Spree
           # Restock things we will not fulfil from the current shipment anymore
           current_stock_location.restock(variant, current_on_hand_quantity, current_shipment)
           # Unstock what we will fulfil with the new shipment
-          desired_stock_location.unstock(variant, new_on_hand_quantity, desired_shipment)
+          desired_stock_location.unstock(variant, unstock_quantity, desired_shipment)
         end
 
         # These two statements are the heart of this class. We change the number

--- a/core/app/models/spree/fulfilment_changer.rb
+++ b/core/app/models/spree/fulfilment_changer.rb
@@ -48,7 +48,7 @@ module Spree
       ActiveRecord::Base.transaction do
         if handle_stock_counts?
           # We only run this query if we need it.
-          current_on_hand_quantity = [current_shipment.inventory_units.on_hand.size, quantity].min
+          current_on_hand_quantity = [current_shipment.inventory_units.pre_shipment.size, quantity].min
 
           # Restock things we will not fulfil from the current shipment anymore
           current_stock_location.restock(variant, current_on_hand_quantity, current_shipment)

--- a/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -124,6 +124,24 @@ RSpec.describe Spree::FulfilmentChanger do
           expect(desired_shipment.inventory_units.backordered.count).to eq(2)
         end
 
+        context "when the desired stock location already has a backordered units" do
+          let(:desired_count_on_hand) { -1 }
+
+          it "restocks seven at the original stock location" do
+            expect { subject }.to change { current_shipment.stock_location.count_on_hand(variant) }.by(7)
+          end
+
+          it "unstocks seven at the desired stock location" do
+            expect { subject }.to change { desired_shipment.stock_location.count_on_hand(variant) }.by(-7)
+          end
+
+          it "creates a shipment with the correct number of on hand and backordered units" do
+            subject
+            expect(desired_shipment.inventory_units.on_hand.count).to eq(0)
+            expect(desired_shipment.inventory_units.backordered.count).to eq(7)
+          end
+        end
+
         context "when the original shipment has on hand and backordered units" do
           before do
             current_shipment.inventory_units.limit(6).update_all(state: :backordered)

--- a/core/spec/models/spree/fulfilment_changer_spec.rb
+++ b/core/spec/models/spree/fulfilment_changer_spec.rb
@@ -110,12 +110,12 @@ RSpec.describe Spree::FulfilmentChanger do
           stock_item.update(backorderable: true)
         end
 
-        it "restocks five at the original stock location" do
+        it "restocks seven at the original stock location" do
           expect { subject }.to change { current_shipment.stock_location.count_on_hand(variant) }.by(7)
         end
 
-        it "unstocks five at the desired stock location" do
-          expect { subject }.to change { desired_shipment.stock_location.count_on_hand(variant) }.by(-5)
+        it "unstocks seven at the desired stock location" do
+          expect { subject }.to change { desired_shipment.stock_location.count_on_hand(variant) }.by(-7)
         end
 
         it "creates a shipment with the correct number of on hand and backordered units" do


### PR DESCRIPTION
We found some problem when moving backordered inventory units across shipments. Specifically the stock items of source and destination aren't restocking unstocking the correct quantity.

### Steps to reproduce
- Create 2 stock location
- Choose one product and set stock items to quantity 10 and both to backorderable.
- Complete an order that requires 15 inventory units.
- Now you have `10 X on hand` and other `5 X backordered` inventory units, something like:
<img width="850" alt="screen shot 2017-10-06 at 12 00 52" src="https://user-images.githubusercontent.com/387690/31286790-92f87eac-aabf-11e7-8d6f-18a13c78d2c9.png">

- Into product stocks section the related stock item is correctly calculated.
<img width="1099" alt="screen shot 2017-10-06 at 12 01 05" src="https://user-images.githubusercontent.com/387690/31286953-035b00d4-aac0-11e7-9ac8-11c01dae946b.png">

- Return to order page and move all inventory units to a new shipment in the other stock location.
<img width="840" alt="screen shot 2017-10-06 at 12 01 45" src="https://user-images.githubusercontent.com/387690/31287003-245af578-aac0-11e7-882b-90a5d8f16b8b.png">

### Expected behavior
The count on hand of source stock item should be restocked to the original value (10), the count on hand of stock item where you move the inventory units to should be negative (-5).

### Actual behavior
The count on hand on default stock item isn't restored, and the second stock location is 0 but should be -5
<img width="1109" alt="screen shot 2017-10-06 at 12 02 20" src="https://user-images.githubusercontent.com/387690/31287042-4bde5f04-aac0-11e7-825d-458024ef989d.png">

### System configuration
2.4 master



### PR
Fix restocking and unstocking items in FulfilmentChanger
This PR fixes issues described in #2285.

Current code is not taking into account some important scenarios, like:
- Desired stock item as negative count on hand amount
- Restock of inventory in backordered state
----





### Example:
Order with `10 x on hand` and `5 x backordered` inventory units.


The count on hand of related stock item is negative.

<img width="1099" alt="screen shot 2017-10-06 at 12 01 05" src="https://user-images.githubusercontent.com/387690/31286953-035b00d4-aac0-11e7-9ac8-11c01dae946b.png">

Move all inventory units to a new shipment with other stock location.

Only the inventory units in `on_hand` state (10) are restored in the original stock item, and only available stock items are moved into the new shipment.