### PR TITLE
Mutating shipments must not mutate line items

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -67,19 +67,6 @@ module Spree
         respond_with(@shipment, default_template: :show)
       end
 
-      def remove
-        quantity = params[:quantity].to_i
-
-        if @shipment.pending?
-          @shipment.order.contents.remove(variant, quantity, { shipment: @shipment })
-          @shipment.reload if @shipment.persisted?
-          respond_with(@shipment, default_template: :show)
-        else
-          @shipment.errors.add(:base, :cannot_remove_items_shipment_state, state: @shipment.state)
-          invalid_resource!(@shipment)
-        end
-      end
-
       def transfer_to_location
         @desired_stock_location = Spree::StockLocation.find(params[:stock_location_id])
         @desired_shipment = @original_shipment.order.shipments.build(stock_location: @desired_stock_location)

--- a/api/spec/requests/spree/api/shipments_controller_spec.rb
+++ b/api/spec/requests/spree/api/shipments_controller_spec.rb
@@ -21,11 +21,6 @@ describe Spree::Api::ShipmentsController, type: :request do
       assert_unauthorized!
     end
 
-    it "cannot remove order contents from shipment" do
-      put spree.remove_api_shipment_path(shipment)
-      assert_unauthorized!
-    end
-
     it "cannot add contents to the shipment" do
       put spree.add_api_shipment_path(shipment)
       assert_unauthorized!
@@ -115,23 +110,6 @@ describe Spree::Api::ShipmentsController, type: :request do
         expect(response.status).to eq(200)
         expect(json_response['manifest'].detect { |h| h['variant']['id'] == variant.id }["quantity"]).to eq(2)
       end
-
-      it 'removes a variant from a shipment' do
-        order.contents.add(variant, 2)
-
-        put spree.remove_api_shipment_path(shipment), params: { variant_id: variant.to_param, quantity: 1 }
-        expect(response.status).to eq(200)
-        expect(json_response['manifest'].detect { |h| h['variant']['id'] == variant.id }["quantity"]).to eq(1)
-      end
-
-      it 'removes a destroyed variant from a shipment' do
-        order.contents.add(variant, 2)
-        variant.destroy
-
-        put spree.remove_api_shipment_path(shipment), params: { variant_id: variant.to_param, quantity: 1 }
-        expect(response.status).to eq(200)
-        expect(json_response['manifest'].detect { |h| h['variant']['id'] == variant.id }["quantity"]).to eq(1)
-      end
     end
 
     context "for shipped shipments" do
@@ -142,12 +120,6 @@ describe Spree::Api::ShipmentsController, type: :request do
         put spree.add_api_shipment_path(shipment), params: { variant_id: variant.to_param, quantity: 2 }
         expect(response.status).to eq(200)
         expect(json_response['manifest'].detect { |h| h['variant']['id'] == variant.id }["quantity"]).to eq(2)
-      end
-
-      it 'cannot remove a variant from a shipment' do
-        put spree.remove_api_shipment_path(shipment), params: { variant_id: variant.to_param, quantity: 1 }
-        expect(response.status).to eq(422)
-        expect(json_response['errors']['base'].join).to match /Cannot remove items/
       end
     end
 

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -23,7 +23,6 @@
     <td class="cart-item-delete actions" data-hook="cart_item_delete">
       <% if can? :update, item %>
         <%= button_tag '', class: 'split-item icon_link fa fa-arrows-h no-text with-tip', data: { action: 'edit', 'variant-id' => item.variant.id }, title: Spree.t('actions.split'), type: :button %>
-        <%= button_tag '', class: 'delete-item fa fa-trash no-text with-tip', data: { action: 'remove', 'variant-id' => item.variant.id }, title: Spree.t('actions.delete'), type: :button %>
       <% end %>
     </td>
   </tr>

--- a/backend/app/views/spree/admin/prices/_form.html.erb
+++ b/backend/app/views/spree/admin/prices/_form.html.erb
@@ -17,8 +17,7 @@
           <%= f.field_hint :country %>
           <%= f.collection_select :country_iso, available_countries, :iso, :name,
                                   {
-                                    include_blank: t(:any_country, scope: [:spree, :admin, :prices]),
-                                    selected: Spree::Config.admin_vat_country_iso
+                                    include_blank: t(:any_country, scope: [:spree, :admin, :prices])
                                   },
                                   { class: 'custom-select fullwidth', disabled: !f.object.new_record? } %>
         <% end %>

--- a/backend/app/views/spree/admin/store_credits/index.html.erb
+++ b/backend/app/views/spree/admin/store_credits/index.html.erb
@@ -30,7 +30,7 @@
           <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:created_at) %></th>
           <th class="wrap-text"><%= Spree::StoreCredit.human_attribute_name(:invalidated_at) %></th>
           <th data-hook="admin_store_credits_index_header_actions" class="actions"></th>
-        <thead>
+        </thead>
         <tbody>
           <% credits.each do |store_credit| %>
             <tr>

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -316,25 +316,6 @@ describe "Order Details", type: :feature, js: true do
         end
       end
 
-      context 'removing an item' do
-        let!(:shipment2) { order.shipments.create(stock_location_id: stock_location2.id) }
-
-        it "removes only the one item" do
-          order.line_items[0].inventory_units[0].update!(shipment: shipment2)
-          visit spree.edit_admin_order_path(order)
-
-          expect(page).to have_css('.stock-item', count: 2)
-
-          within '[data-hook=admin_shipment_form]', text: shipment2.number do
-            accept_confirm "Are you sure you want to delete this record?" do
-              click_icon :trash
-            end
-          end
-
-          expect(page).to have_css('.stock-item', count: 1)
-        end
-      end
-
       context 'splitting to shipment' do
         let!(:shipment2) { order.shipments.create(stock_location_id: stock_location2.id) }
 

--- a/core/app/models/spree/classification.rb
+++ b/core/app/models/spree/classification.rb
@@ -2,7 +2,7 @@ module Spree
   class Classification < Spree::Base
     self.table_name = 'spree_products_taxons'
     acts_as_list scope: :taxon
-    belongs_to :product, class_name: "Spree::Product", inverse_of: :classifications
+    belongs_to :product, class_name: "Spree::Product", inverse_of: :classifications, touch: true
     belongs_to :taxon, class_name: "Spree::Taxon", inverse_of: :classifications, touch: true
 
     # For https://github.com/spree/spree/issues/3494

--- a/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_transfer_factory.rb
@@ -1,9 +1,12 @@
 FactoryGirl.define do
-  factory :stock_transfer, class: 'Spree::StockTransfer' do
-    source_location { Spree::StockLocation.create!(name: "Source Location", code: "SRC", admin_name: "Source") }
+  sequence(:source_code) { |n| "SRC#{n}" }
+  sequence(:destination_code) { |n| "DEST#{n}" }
+
+  factory :stock_transfer, class: Spree::StockTransfer do
+    source_location { Spree::StockLocation.create!(name: "Source Location", code: generate(:source_code), admin_name: "Source") }
 
     factory :stock_transfer_with_items do
-      destination_location { Spree::StockLocation.create!(name: "Destination Location", code: "DEST", admin_name: "Destination") }
+      destination_location { Spree::StockLocation.create!(name: "Destination Location", code: generate(:destination_code), admin_name: "Destination") }
 
       after(:create) do |stock_transfer, _evaluator|
         variant_1 = create(:variant)

--- a/core/spec/models/spree/classification_spec.rb
+++ b/core/spec/models/spree/classification_spec.rb
@@ -89,5 +89,22 @@ module Spree
         expect positions_to_be_valid(taxon_with_5_products)
       end
     end
+
+    it "touches the product" do
+      taxon = taxon_with_5_products
+      classification = taxon.classifications.first
+      product = classification.product
+      expect {
+        classification.touch
+      }.to change { product.reload.updated_at }
+    end
+
+    it "touches the taxon" do
+      taxon = taxon_with_5_products
+      classification = taxon.classifications.first
+      expect {
+        classification.touch
+      }.to change { taxon.reload.updated_at }
+    end
   end
 end


### PR DESCRIPTION
This pull request wants to solve this issue: https://github.com/solidusio/solidus/issues/2235

If there are two or more shipments for one order and the user delete one of these, the line items of order are modified.
To overcome this problem I removed destroy action from shipment so to force the user to use split action to add, modify or delete shipments.