### PR TITLE
Mutating shipments must not mutate line items

### DIFF
--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -67,19 +67,6 @@ module Spree
         respond_with(@shipment, default_template: :show)
       end
 
-      def remove
-        quantity = params[:quantity].to_i
-
-        if @shipment.pending?
-          @shipment.order.contents.remove(variant, quantity, { shipment: @shipment })
-          @shipment.reload if @shipment.persisted?
-          respond_with(@shipment, default_template: :show)
-        else
-          @shipment.errors.add(:base, :cannot_remove_items_shipment_state, state: @shipment.state)
-          invalid_resource!(@shipment)
-        end
-      end
-
       def transfer_to_location
         @desired_stock_location = Spree::StockLocation.find(params[:stock_location_id])
         @desired_shipment = @original_shipment.order.shipments.build(stock_location: @desired_stock_location)

--- a/api/spec/requests/spree/api/shipments_controller_spec.rb
+++ b/api/spec/requests/spree/api/shipments_controller_spec.rb
@@ -21,11 +21,6 @@ describe Spree::Api::ShipmentsController, type: :request do
       assert_unauthorized!
     end
 
-    it "cannot remove order contents from shipment" do
-      put spree.remove_api_shipment_path(shipment)
-      assert_unauthorized!
-    end
-
     it "cannot add contents to the shipment" do
       put spree.add_api_shipment_path(shipment)
       assert_unauthorized!
@@ -115,23 +110,6 @@ describe Spree::Api::ShipmentsController, type: :request do
         expect(response.status).to eq(200)
         expect(json_response['manifest'].detect { |h| h['variant']['id'] == variant.id }["quantity"]).to eq(2)
       end
-
-      it 'removes a variant from a shipment' do
-        order.contents.add(variant, 2)
-
-        put spree.remove_api_shipment_path(shipment), params: { variant_id: variant.to_param, quantity: 1 }
-        expect(response.status).to eq(200)
-        expect(json_response['manifest'].detect { |h| h['variant']['id'] == variant.id }["quantity"]).to eq(1)
-      end
-
-      it 'removes a destroyed variant from a shipment' do
-        order.contents.add(variant, 2)
-        variant.destroy
-
-        put spree.remove_api_shipment_path(shipment), params: { variant_id: variant.to_param, quantity: 1 }
-        expect(response.status).to eq(200)
-        expect(json_response['manifest'].detect { |h| h['variant']['id'] == variant.id }["quantity"]).to eq(1)
-      end
     end
 
     context "for shipped shipments" do
@@ -142,12 +120,6 @@ describe Spree::Api::ShipmentsController, type: :request do
         put spree.add_api_shipment_path(shipment), params: { variant_id: variant.to_param, quantity: 2 }
         expect(response.status).to eq(200)
         expect(json_response['manifest'].detect { |h| h['variant']['id'] == variant.id }["quantity"]).to eq(2)
-      end
-
-      it 'cannot remove a variant from a shipment' do
-        put spree.remove_api_shipment_path(shipment), params: { variant_id: variant.to_param, quantity: 1 }
-        expect(response.status).to eq(422)
-        expect(json_response['errors']['base'].join).to match /Cannot remove items/
       end
     end
 

--- a/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
+++ b/backend/app/views/spree/admin/orders/_shipment_manifest.html.erb
@@ -23,7 +23,6 @@
     <td class="cart-item-delete actions" data-hook="cart_item_delete">
       <% if can? :update, item %>
         <%= button_tag '', class: 'split-item icon_link fa fa-arrows-h no-text with-tip', data: { action: 'edit', 'variant-id' => item.variant.id }, title: Spree.t('actions.split'), type: :button %>
-        <%= button_tag '', class: 'delete-item fa fa-trash no-text with-tip', data: { action: 'remove', 'variant-id' => item.variant.id }, title: Spree.t('actions.delete'), type: :button %>
       <% end %>
     </td>
   </tr>

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -316,25 +316,6 @@ describe "Order Details", type: :feature, js: true do
         end
       end
 
-      context 'removing an item' do
-        let!(:shipment2) { order.shipments.create(stock_location_id: stock_location2.id) }
-
-        it "removes only the one item" do
-          order.line_items[0].inventory_units[0].update!(shipment: shipment2)
-          visit spree.edit_admin_order_path(order)
-
-          expect(page).to have_css('.stock-item', count: 2)
-
-          within '[data-hook=admin_shipment_form]', text: shipment2.number do
-            accept_confirm "Are you sure you want to delete this record?" do
-              click_icon :trash
-            end
-          end
-
-          expect(page).to have_css('.stock-item', count: 1)
-        end
-      end
-
       context 'splitting to shipment' do
         let!(:shipment2) { order.shipments.create(stock_location_id: stock_location2.id) }
 


### PR DESCRIPTION
This pull request wants to solve this issue: solidusio#2235

If there are two or more shipments for one order and the user delete one of these, the line items of order are modified.
To overcome this problem I removed destroy action from shipment so to force the user to use split action to add, modify or delete shipments.