### PR TITLE
Remove unused path promotion code type from admin

### DIFF
--- a/backend/app/views/spree/admin/promotions/_activations_new.html.erb
+++ b/backend/app/views/spree/admin/promotions/_activations_new.html.erb
@@ -19,12 +19,6 @@
         <%= t('.multiple_codes') %>
       </label>
     </div>
-    <div class="form-check">
-      <label class="form-check-label">
-        <%= radio_button_tag('activation_type', 'path', activation_type == 'path') %>
-        <%= t('.path') %>
-      </label>
-    </div>
   </div>
   <div class="col-9">
     <input name="promotion[apply_automatically]" type="hidden" value="0">
@@ -54,13 +48,6 @@
           <%= f.text_field :per_code_usage_limit, class: "fullwidth" %>
         </div>
       <% end %>
-    </div>
-
-    <div data-activation-type="path">
-      <div class="field" id="promotion_path_field">
-        <%= f.label :path, class: "required" %>
-        <%= f.text_field :path, class: "fullwidth", required: true %>
-      </div>
     </div>
   </div>
 </div>

--- a/backend/spec/features/admin/promotion_adjustments_spec.rb
+++ b/backend/spec/features/admin/promotion_adjustments_spec.rb
@@ -178,20 +178,6 @@ describe "Promotion Adjustments", type: :feature, js: true do
       expect(promotion.rules).to be_blank
     end
 
-    it "should allow an admin to create a promo requiring a landing page to be visited" do
-      fill_in "Name", with: "SAVE SAVE SAVE"
-      choose "URL Path"
-      fill_in "Path", with: "content/cvv"
-      click_button "Create"
-      expect(page).to have_title("SAVE SAVE SAVE - Promotions")
-
-      promotion = Spree::Promotion.find_by(name: "SAVE SAVE SAVE")
-      expect(promotion.path).to eq("content/cvv")
-      expect(promotion).not_to be_apply_automatically
-      expect(promotion.codes).to be_empty
-      expect(promotion.rules).to be_blank
-    end
-
     it "should allow an admin to create a promo with generated codes" do
       fill_in "Name", with: "SAVE SAVE SAVE"
       choose "Multiple promotion codes"


### PR DESCRIPTION
This feature was removed since 2015 but the admin UI is misleading
because still allowed to add a path promotion code which is impossible
to redeem.

Ref solidusio#2246