### PR TITLE
Recalculate order after reimbursement creation

### DIFF
--- a/backend/app/controllers/spree/admin/reimbursements_controller.rb
+++ b/backend/app/controllers/spree/admin/reimbursements_controller.rb
@@ -9,6 +9,7 @@ module Spree
 
       before_action :load_stock_locations, only: :edit
       before_action :load_simulated_refunds, only: :edit
+      create.after :recalculate_order
 
       rescue_from Spree::Core::GatewayError, with: :spree_core_gateway_error
 
@@ -18,6 +19,10 @@ module Spree
       end
 
       private
+
+      def recalculate_order
+        @reimbursement.order.recalculate
+      end
 
       def build_resource
         if params[:build_from_customer_return_id].present?

--- a/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/reimbursements_controller_spec.rb
@@ -42,6 +42,10 @@ describe Spree::Admin::ReimbursementsController, type: :controller do
       expect(assigns(:reimbursement).return_items.to_a).to eq customer_return.return_items.to_a
     end
 
+    it 'order is recalculated' do
+      expect { subject }.to change { order.reload.payment_state }.from('paid').to('credit_owed')
+    end
+
     it 'redirects to the edit page' do
       subject
       expect(response).to redirect_to(spree.edit_admin_order_reimbursement_path(order, assigns(:reimbursement)))

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -18,6 +18,7 @@ module Spree
     accepts_nested_attributes_for :return_items, allow_destroy: true
 
     before_create :generate_number
+    before_create :calculate_total
 
     scope :reimbursed, -> { where(reimbursement_status: 'reimbursed') }
 
@@ -147,6 +148,10 @@ module Spree
     end
 
     private
+
+    def calculate_total
+      self.total ||= calculated_total
+    end
 
     def generate_number
       self.number ||= loop do

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -3,6 +3,28 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Reimbursement, type: :model do
+  describe ".create" do
+    let(:customer_return) { create(:customer_return) }
+    let(:order) { customer_return.order }
+    let(:reimbursement) { build(:reimbursement, order: order) }
+
+    subject { reimbursement.save }
+
+    context "when total is not present" do
+      before do
+        allow(reimbursement).to receive(:calculated_total) { 100 }
+      end
+
+      it { expect { subject }.to change(reimbursement, :total).from(nil).to(100.0) }
+    end
+
+    context "when total is present" do
+      let(:reimbursement) { build(:reimbursement, order: order, total: 10) }
+
+      it { expect { subject }.not_to change(reimbursement, :total).from(10) }
+    end
+  end
+
   describe ".before_create" do
     describe "#generate_number" do
       context "number is assigned" do


### PR DESCRIPTION
This PR is going to fix the issue https://github.com/solidusio/solidus/issues/2606

The issue happens because after reimbursement creation the order is not recalculated.
To fix it we run `order#recalculate` in `after_create` callback, in this way `order#payment_state` is updated to new state.
