### PR TITLE
Add an allocator class to extend the Solidus initial allocation logic

### DIFF
--- a/core/app/models/spree/stock/allocator/base.rb
+++ b/core/app/models/spree/stock/allocator/base.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Spree
+  module Stock
+    module Allocator
+      class Base
+        attr_reader :availability
+
+        def initialize(availability)
+          @availability = availability
+        end
+
+        def allocate_inventory(desired)
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/stock/allocator/on_hand_first.rb
+++ b/core/app/models/spree/stock/allocator/on_hand_first.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Spree
+  module Stock
+    module Allocator
+      class OnHandFirst < Spree::Stock::Allocator::Base
+        def allocate_inventory(desired)
+          # Allocate any available on hand inventory
+          on_hand = allocate_on_hand(desired)
+          desired -= on_hand.values.sum if on_hand.present?
+
+          # Allocate remaining desired inventory from backorders
+          backordered = allocate_backordered(desired)
+          desired -= backordered.values.sum if backordered.present?
+
+          # If all works at this point desired must be empty
+          [on_hand, backordered, desired]
+        end
+
+        protected
+
+        def allocate_on_hand(desired)
+          allocate(availability.on_hand_by_stock_location_id, desired)
+        end
+
+        def allocate_backordered(desired)
+          allocate(availability.backorderable_by_stock_location_id, desired)
+        end
+
+        def allocate(availability_by_location, desired)
+          availability_by_location.transform_values do |available|
+            # Find the desired inventory which is available at this location
+            packaged = available & desired
+            # Remove found inventory from desired
+            desired -= packaged
+            packaged
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/spree/stock/simple_coordinator.rb
+++ b/core/app/models/spree/stock/simple_coordinator.rb
@@ -11,6 +11,9 @@ module Spree
     #   * Repeat but for backordered inventory
     #   * Combine allocated and on hand inventory into a single shipment per-location
     #
+    # Allocation logic can be changed using a custom class (as
+    # configured in Spree::Config::stock_allocator_class )
+    #
     # After allocation, splitters are run on each Package (as configured in
     # Spree::Config.environment.stock_splitters)
     #
@@ -31,6 +34,8 @@ module Spree
           variants: @desired.variants,
           stock_locations: @stock_locations
         )
+
+        @allocator = Spree::Config.stock_allocator_class.new(@availability)
       end
 
       def shipments
@@ -40,13 +45,10 @@ module Spree
       private
 
       def build_shipments
-        # Allocate any available on hand inventory
-        on_hand_packages = allocate_inventory(@availability.on_hand_by_stock_location_id)
+        # Allocate any available on hand inventory and remaining desired inventory from backorders
+        on_hand_packages, backordered_packages, leftover = @allocator.allocate_inventory(@desired)
 
-        # allocate any remaining desired inventory from backorders
-        backordered_packages = allocate_inventory(@availability.backorderable_by_stock_location_id)
-
-        unless @desired.empty?
+        unless leftover.empty?
           raise Spree::Order::InsufficientStock
         end
 
@@ -88,13 +90,13 @@ module Spree
         availability_by_location.transform_values do |available|
           # Find the desired inventory which is available at this location
           packaged = available & @desired
-
           # Remove found inventory from desired
           @desired -= packaged
-
           packaged
         end
       end
+      deprecate allocate_inventory: 'allocate_inventory is deprecated. Please write your own allocator defining' \
+        'a Spree::Stock::Allocator::Base subclass', deprecator: Spree::Deprecation
 
       def get_units(quantities)
         # Change our raw quantities back into inventory units

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -381,6 +381,13 @@ module Spree
     # returns a String
     class_name_attribute :taxon_url_parametizer_class, default: 'ActiveSupport::Inflector'
 
+    # Allows providing your own class to allocate the inventory into packages
+    #
+    # @!attribute [rw] taxon_url_parametizer_class
+    # @return [Class] a class that provides a `#allocate_on_hand` and `#allocate_backorderable` method that
+    # returns a Spree::StockQuantities
+    class_name_attribute :stock_allocator_class, default: 'Spree::Stock::Allocator::OnHandFirst'
+
     # Allows providing your own class instance for generating order numbers.
     #
     # @!attribute [rw] order_number_generator

--- a/core/spec/models/spree/stock/allocator/on_hand_first_spec.rb
+++ b/core/spec/models/spree/stock/allocator/on_hand_first_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Spree
+  module Stock
+    module Allocator
+      RSpec.describe OnHandFirst, type: :model do
+        subject { described_class.new(availability) }
+
+        let(:availability) { double(Spree::Stock::Availability) }
+
+        let!(:default_stock_location) { create(:stock_location, default: true, backorderable_default: false) }
+        let!(:backorderable_stock_location) { create(:stock_location) }
+
+        let(:first_variant) { create(:variant) }
+        let(:second_variant) { create(:variant) }
+
+        let(:desired_quantities) do
+          quantities = {}
+          quantities[first_variant] = first_variant_desired
+          quantities[second_variant] = second_variant_desired
+          quantities
+        end
+
+        let(:desired) { Spree::StockQuantities.new(desired_quantities) }
+
+        describe '#allocate_inventory' do
+          let(:default_on_hand_availability) do
+            quantities = {}
+            quantities[first_variant] = first_variant_default_availability
+            quantities[second_variant] = second_variant_default_availability
+            quantities
+          end
+
+          let(:dropship_on_hand_availability) do
+            quantities = {}
+            quantities[first_variant] = first_variant_dropship_availability
+            quantities[second_variant] = second_variant_dropship_availability
+            quantities
+          end
+
+          let(:on_hand_by_stock_location_id) do
+            availability = {}
+            availability[default_stock_location.id] = Spree::StockQuantities.new(default_on_hand_availability)
+            availability[backorderable_stock_location.id] = Spree::StockQuantities.new(dropship_on_hand_availability)
+            availability
+          end
+
+          let(:dropship_backorderable_availability) do
+            quantities = {}
+            quantities[first_variant] = Float::INFINITY
+            quantities[second_variant] = Float::INFINITY
+            quantities
+          end
+
+          let(:backorderable_by_stock_location_id) do
+            availability = {}
+            availability[backorderable_stock_location.id] = Spree::StockQuantities.new(dropship_backorderable_availability)
+            availability
+          end
+
+          before do
+            allow(availability).to receive(:on_hand_by_stock_location_id)
+              .and_return(on_hand_by_stock_location_id)
+
+            allow(availability).to receive(:backorderable_by_stock_location_id)
+              .and_return(backorderable_by_stock_location_id)
+          end
+
+          context 'when default stock location has enough items' do
+            let(:first_variant_default_availability) { 100 }
+            let(:second_variant_default_availability) { 100 }
+            let(:first_variant_dropship_availability) { 0 }
+            let(:second_variant_dropship_availability) { 0 }
+            let(:first_variant_desired) { 30 }
+            let(:second_variant_desired) { 5 }
+
+            it 'allocates all the desired units on the default stock location' do
+              on_hand_packages, backordered_packages, leftover = subject.allocate_inventory(desired)
+
+              expect(on_hand_packages[default_stock_location.id][first_variant]).to eq(30)
+              expect(on_hand_packages[default_stock_location.id][second_variant]).to eq(5)
+              expect(on_hand_packages[backorderable_stock_location.id][first_variant]).to eq(0)
+              expect(on_hand_packages[backorderable_stock_location.id][second_variant]).to eq(0)
+
+              expect(backordered_packages[backorderable_stock_location.id][first_variant]).to eq(0)
+              expect(backordered_packages[backorderable_stock_location.id][second_variant]).to eq(0)
+
+              expect(leftover[first_variant]).to eq(0)
+              expect(leftover[second_variant]).to eq(0)
+            end
+          end
+
+          context 'when default stock location hasn\'t enough items' do
+            let(:first_variant_default_availability) { 10 }
+            let(:second_variant_default_availability) { 10 }
+
+            let(:first_variant_desired) { 15 }
+            let(:second_variant_desired) { 5 }
+
+            context 'when dropship stock location has enough items' do
+              let(:first_variant_dropship_availability) { 20 }
+              let(:second_variant_dropship_availability) { 0 }
+
+              it 'allocates all the desired units on the stock locations while stocks last' do
+                on_hand_packages, backordered_packages, leftover = subject.allocate_inventory(desired)
+
+                expect(on_hand_packages[default_stock_location.id][first_variant]).to eq(10)
+                expect(on_hand_packages[default_stock_location.id][second_variant]).to eq(5)
+                expect(on_hand_packages[backorderable_stock_location.id][first_variant]).to eq(5)
+                expect(on_hand_packages[backorderable_stock_location.id][second_variant]).to eq(0)
+
+                expect(backordered_packages[backorderable_stock_location.id][first_variant]).to eq(0)
+                expect(backordered_packages[backorderable_stock_location.id][second_variant]).to eq(0)
+
+                expect(leftover[first_variant]).to eq(0)
+                expect(leftover[second_variant]).to eq(0)
+              end
+            end
+
+            context 'when dropship stock location hasn\'t enough items' do
+              let(:first_variant_dropship_availability) { 2 }
+              let(:second_variant_dropship_availability) { 0 }
+
+              it 'allocates all the desired units on the stock locations while stocks last' do
+                on_hand_packages, backordered_packages, leftover = subject.allocate_inventory(desired)
+
+                expect(on_hand_packages[default_stock_location.id][first_variant]).to eq(10)
+                expect(on_hand_packages[default_stock_location.id][second_variant]).to eq(5)
+                expect(on_hand_packages[backorderable_stock_location.id][first_variant]).to eq(2)
+                expect(on_hand_packages[backorderable_stock_location.id][second_variant]).to eq(0)
+
+                expect(backordered_packages[backorderable_stock_location.id][first_variant]).to eq(3)
+                expect(backordered_packages[backorderable_stock_location.id][second_variant]).to eq(0)
+
+                expect(leftover[first_variant]).to eq(0)
+                expect(leftover[second_variant]).to eq(0)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/stock/simple_coordinator_spec.rb
+++ b/core/spec/models/spree/stock/simple_coordinator_spec.rb
@@ -15,6 +15,11 @@ module Spree
           subject.shipments
         end
 
+        it 'uses the pluggable allocator class' do
+          expect(Spree::Config).to receive(:stock_allocator_class).and_call_original
+          subject.shipments
+        end
+
         it 'builds shipments' do
           expect(subject.shipments.size).to eq(1)
         end
@@ -38,6 +43,13 @@ module Spree
           }.not_to change {
             order.shipments.count
           }
+        end
+      end
+
+      describe "#allocate_inventory" do
+        it 'is deprecated' do
+          expect(Spree::Deprecation).to receive(:warn)
+          subject.send :allocate_inventory, subject.instance_variable_get(:@availability).on_hand_by_stock_location_id
         end
       end
 


### PR DESCRIPTION
With this PR we add the possibility to change the stock allocation logic 
using a custom class without overriding the allocate_inventory method in 
SimpleCoordinator.

## How it works

### Default class 
Without changing the Solidus default stock allocation, I wrote a `Spree::Stock::Allocator::OnHandFirst` allocator with the same logic of the `allocate_inventory` [method](https://github.com/solidusio/solidus/blob/fa98d6523571142fe4c23120cf281f0f6d1b0aa7/core/app/models/spree/stock/simple_coordinator.rb#L87).

### How to override Solidus default stock allocation
You can tell the `SimpleCoordinator` to use a custom allocator overriding the `Spree` configuration: `Spree::Config::stock_allocator_class`

### How to write a custom allocator
To write a custom stock allocator you can extend `Spree::Stock::Allocator::Base` if you also want to change the allocation priority ( on hand first or backorderable first ). Otherwise, you can extend `Spree::Stock::Allocator::OnHandFirst` to only change the allocation logic. 