### PR TITLE
Fix Spree::Shipment#item_cost for split shipments

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -186,7 +186,7 @@ module Spree
     end
 
     def item_cost
-      line_items.map(&:total).sum
+      manifest.map { |m| (m.line_item.price + (m.line_item.adjustment_total / m.line_item.quantity)) * m.quantity }.sum
     end
 
     def ready_or_pending?

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -141,6 +141,26 @@ RSpec.describe Spree::Shipment, type: :model do
     it 'should equal line items final amount with tax' do
       expect(shipment.item_cost).to eql(11.0)
     end
+
+    context 'whit more shipments for the same line_item' do
+      let(:order) do
+        create(
+          :order_with_line_items,
+          line_items_attributes: [{ price: 10, variant: variant, quantity: 2 }],
+          ship_address: ship_address,
+        )
+      end
+      let(:other_shipment) { order.shipments.create(stock_location_id: shipment.stock_location) }
+
+      it 'should equal shipment line items amount with tax' do
+        expect(order.shipments.first.item_cost).to eql(22.0)
+        expect {
+          order.inventory_units.last.update(shipment_id: other_shipment.id)
+        }.to change { order.shipments.reload.first.item_cost }.from(22.0).to(11.0)
+
+        expect(order.shipments.second.item_cost).to eql(11.0)
+      end
+    end
   end
 
   it "#discounted_cost" do


### PR DESCRIPTION
This commit is going to fix the bug reported here #2919.

Now when shipment is split, it creates two shipment but associated
line_item has quantity 2 which is resulting in incorrect item_cost
because it is taken from line_item not from shipment.
Shipment manifest know the right quantity for every shipment, use it to
calculate the item_cost as sum of

`(single_line item + weighted adjustment per line item) * quantity`