### PR TITLE
Extract and improve PaperclipDeprecatedAPI module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,12 @@ jobs:
     parallelism: *parallelism
     steps: *steps
 
+  postgres_activestorage:
+    <<: *postgres
+    environment:
+      <<: *environment
+      ACTIVE_STORAGE: 'true'
+
   postgres_rails51:
     <<: *postgres
     environment:
@@ -79,3 +85,4 @@ workflows:
       - mysql
       - postgres_rails51
       - mysql_rails51
+      - postgres_activestorage

--- a/api/app/controllers/spree/api/base_controller.rb
+++ b/api/app/controllers/spree/api/base_controller.rb
@@ -23,6 +23,11 @@ module Spree
       before_action :authorize_for_order, if: proc { order_token.present? }
       before_action :authenticate_user
       before_action :load_user_roles
+      if defined? ActiveStorage
+        before_action do
+          ActiveStorage::Current.host = request.base_url
+        end
+      end
 
       rescue_from ActionController::ParameterMissing, with: :parameter_missing_error
       rescue_from ActiveRecord::RecordNotFound, with: :not_found

--- a/api/app/views/spree/api/images/_image.json.jbuilder
+++ b/api/app/views/spree/api/images/_image.json.jbuilder
@@ -3,5 +3,5 @@
 json.(image, *image_attributes)
 json.(image, :viewable_type, :viewable_id)
 Spree::Image.attachment_definitions[:attachment][:styles].each do |k, _v|
-  json.set! "#{k}_url", image.attachment.url(k)
+  json.set! "#{k}_url", image.url(k)
 end

--- a/backend/app/views/spree/admin/taxons/_form.html.erb
+++ b/backend/app/views/spree/admin/taxons/_form.html.erb
@@ -23,7 +23,7 @@
     <%= f.field_container :icon do %>
       <%= f.label :icon %><br />
       <%= f.file_field :icon %>
-      <%= image_tag f.object.icon(:mini) if f.object.icon.present? %>
+      <%= image_tag f.object.icon(:mini) if f.object.icon_present? %>
     <% end %>
   </div>
 

--- a/core/app/controllers/spree/base_controller.rb
+++ b/core/app/controllers/spree/base_controller.rb
@@ -11,5 +11,11 @@ class Spree::BaseController < ApplicationController
   include Spree::Core::ControllerHelpers::Store
   include Spree::Core::ControllerHelpers::StrongParameters
 
+  if defined? ActiveStorage
+    before_action do
+      ActiveStorage::Current.host = request.base_url
+    end
+  end
+
   respond_to :html
 end

--- a/core/app/models/concerns/spree/active_storage_attachment.rb
+++ b/core/app/models/concerns/spree/active_storage_attachment.rb
@@ -4,6 +4,24 @@ module Spree
   module ActiveStorageAttachment
     extend ActiveSupport::Concern
 
+    # @private
+    def self.attachment_variant(attachment, style:, default_style:, styles:)
+      return unless attachment && attachment.attachment
+
+      if style.nil? || style == default_style
+        attachment_variant = attachment
+      else
+        attachment_variant = attachment.variant(
+          resize: styles[style.to_sym],
+          strip: true,
+          'auto-orient': true,
+          colorspace: 'sRGB',
+        ).processed
+      end
+
+      attachment_variant
+    end
+
     class_methods do
       def redefine_attachment_writer_with_legacy_io_support(name)
         define_method :"#{name}=" do |attachable|

--- a/core/app/models/concerns/spree/active_storage_attachment.rb
+++ b/core/app/models/concerns/spree/active_storage_attachment.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Spree
+  module ActiveStorageAttachment
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def redefine_attachment_writer_with_legacy_io_support(name)
+        define_method :"#{name}=" do |attachable|
+          attachment = public_send(name)
+
+          case attachable
+          when ActiveStorage::Blob, ActionDispatch::Http::UploadedFile,
+               Rack::Test::UploadedFile, Hash, String
+            attachment.attach(attachable)
+          when ActiveStorage::Attached
+            attachment.attach(attachable.blob)
+          else # assume it's an IO
+            if attachable.respond_to?(:to_path)
+              filename = attachable.to_path
+            else
+              filename = SecureRandom.uuid
+            end
+            attachable.rewind
+
+            attachment.attach(
+              io: attachable,
+              filename: filename
+            )
+          end
+        end
+      end
+
+      def validate_attachment_to_be_an_image(name)
+        method_name = :"attached_#{name}_is_an_image"
+
+        define_method method_name do
+          attachment = public_send(name)
+          next if attachment.nil? || attachment.attachment.nil?
+
+          errors.add name, 'is not an image' unless attachment.attachment.image?
+        end
+
+        validate method_name
+      end
+    end
+  end
+end

--- a/core/app/models/concerns/spree/deprecated_paperclip_api.rb
+++ b/core/app/models/concerns/spree/deprecated_paperclip_api.rb
@@ -30,5 +30,13 @@ module Spree
         super
       end
     end
+
+    def attachment?
+      Spree::Deprecation.warn(
+        "Using #{self.class}#attachment? is deprecated, please use "\
+        "`#{self.class}#attachment_present?` instead."
+      )
+      attachment.attached?
+    end
   end
 end

--- a/core/app/models/concerns/spree/deprecated_paperclip_api.rb
+++ b/core/app/models/concerns/spree/deprecated_paperclip_api.rb
@@ -2,6 +2,17 @@
 
 module Spree
   module DeprecatedPaperclipAPI
+    def self.prepended(base)
+      unless ActiveStorage::Attached.public_methods.include?(:url)
+        ActiveStorage::Attached.define_method :url do |*args|
+          Spree::Deprecation.warn(
+            "Using #{self.class}#url is deprecated, please use `#{record.class}#url` instead."
+          )
+          record&.url(*args)
+        end
+      end
+    end
+
     def attachment(*args)
       if args.size == 1
         Spree::Deprecation.warn(

--- a/core/app/models/concerns/spree/deprecated_paperclip_api.rb
+++ b/core/app/models/concerns/spree/deprecated_paperclip_api.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Spree
+  module DeprecatedPaperclipAPI
+    def attachment(*args)
+      if args.size == 1
+        Spree::Deprecation.warn(
+          "Using #{self.class}#attachment(<format>) is deprecated, please use `#{self.class}#url` instead."
+        )
+        style = args.first
+        Spree::ActiveStorageAttachment.attachment_variant(
+          super(),
+          style: style,
+          default_style: default_style,
+          styles: self.class::ATTACHMENT_STYLES
+        )&.service_url
+      else
+        # With 0 args will be ok, otherwise will raise an ArgumentError
+        super
+      end
+    end
+  end
+end

--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -2,55 +2,28 @@
 
 module Spree
   class Image < Asset
-    validate :no_attachment_errors
+    if ::Spree::Config.image_attachment_module.blank?
+      Spree::Deprecation.warn <<-MESSAGE.strip_heredoc + "\n\n"
+        Using Paperclip as image_attachment_module for Solidus.
 
-    has_attached_file :attachment,
-                      styles: { mini: '48x48>', small: '100x100>', product: '240x240>', large: '600x600>' },
-                      default_style: :product,
-                      default_url: 'noimage/:style.png',
-                      url: '/spree/products/:id/:style/:basename.:extension',
-                      path: ':rails_root/public/spree/products/:id/:style/:basename.:extension',
-                      convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
-    validates_attachment :attachment,
-      presence: true,
-      content_type: { content_type: %w(image/jpeg image/jpg image/png image/gif) }
+        Please configure Spree::Config.image_attachment_module in your store
+        initializer.
 
-    # save the w,h of the original image (from which others can be calculated)
-    # we need to look at the write-queue for images which have not been saved yet
-    after_post_process :find_dimensions, if: :valid?
+        To use the Paperclip adapter
+          Spree.config do |config|
+            config.image_attachment_module = 'Spree::Image::PaperclipAttachment'
+          end
+      MESSAGE
+      ::Spree::Config.image_attachment_module = 'Spree::Image::PaperclipAttachment'
+    end
+
+    include ::Spree::Config.image_attachment_module.to_s.constantize
 
     def mini_url
       Spree::Deprecation.warn(
         'Spree::Image#mini_url is DEPRECATED. Use Spree::Image#url(:mini) instead.'
       )
-      attachment.url(:mini, false)
-    end
-
-    def url(size)
-      attachment.url(size)
-    end
-
-    def filename
-      attachment_file_name
-    end
-
-    def find_dimensions
-      temporary = attachment.queued_for_write[:original]
-      filename = temporary.path unless temporary.nil?
-      filename = attachment.path if filename.blank?
-      geometry = Paperclip::Geometry.from_file(filename)
-      self.attachment_width  = geometry.width
-      self.attachment_height = geometry.height
-    end
-
-    # if there are errors from the plugin, then add a more meaningful message
-    def no_attachment_errors
-      unless attachment.errors.empty?
-        # uncomment this to get rid of the less-than-useful interim messages
-        # errors.clear
-        errors.add :attachment, "Paperclip returned errors for file '#{attachment_file_name}' - check ImageMagick installation or image source file."
-        false
-      end
+      url(:mini, false)
     end
   end
 end

--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -9,7 +9,12 @@ module Spree
         Please configure Spree::Config.image_attachment_module in your store
         initializer.
 
-        To use the Paperclip adapter
+        To use the ActiveStorage adapter (recommended):
+          Spree.config do |config|
+            config.image_attachment_module = 'Spree::Image::ActiveStorageAttachment'
+          end
+
+        To use the Paperclip adapter (legacy, deprecated):
           Spree.config do |config|
             config.image_attachment_module = 'Spree::Image::PaperclipAttachment'
           end

--- a/core/app/models/spree/image/active_storage_attachment.rb
+++ b/core/app/models/spree/image/active_storage_attachment.rb
@@ -6,30 +6,12 @@ module Spree::Image::ActiveStorageAttachment
   extend ActiveSupport::Concern
   include Spree::ActiveStorageAttachment
 
-  module DeprecatedPaperclipAPI
-    def attachment(*args)
-      if args.size == 1
-        # TODO: deprecation
-        style = args.first
-        Spree::ActiveStorageAttachment.attachment_variant(
-          super(),
-          style: style,
-          default_style: default_style,
-          styles: ATTACHMENT_STYLES
-        )
-      else
-        # With 0 args will be ok, otherwise will raise an ArgumentError
-        super
-      end
-    end
-  end
-
   included do
     has_one_attached :attachment
     redefine_attachment_writer_with_legacy_io_support :attachment
     validate_attachment_to_be_an_image :attachment
     validates :attachment, presence: true
-    prepend DeprecatedPaperclipAPI
+    prepend Spree::DeprecatedPaperclipAPI
   end
 
   class_methods do

--- a/core/app/models/spree/image/active_storage_attachment.rb
+++ b/core/app/models/spree/image/active_storage_attachment.rb
@@ -6,11 +6,30 @@ module Spree::Image::ActiveStorageAttachment
   extend ActiveSupport::Concern
   include Spree::ActiveStorageAttachment
 
+  module DeprecatedPaperclipAPI
+    def attachment(*args)
+      if args.size == 1
+        # TODO: deprecation
+        style = args.first
+        Spree::ActiveStorageAttachment.attachment_variant(
+          super(),
+          style: style,
+          default_style: default_style,
+          styles: ATTACHMENT_STYLES
+        )&.service_url(options)
+      else
+        # With 0 args will be ok, otherwise will raise an ArgumentError
+        super
+      end
+    end
+  end
+
   included do
     has_one_attached :attachment
     redefine_attachment_writer_with_legacy_io_support :attachment
     validate_attachment_to_be_an_image :attachment
     validates :attachment, presence: true
+    prepend DeprecatedPaperclipAPI
   end
 
   class_methods do
@@ -31,23 +50,14 @@ module Spree::Image::ActiveStorageAttachment
   end
 
   def url(style = default_style, options = {})
-    return unless attachment && attachment.attachment
-
-    style = style.to_sym
     options = normalize_url_options(options)
 
-    if style == default_style
-      attachment_variant = attachment
-    else
-      attachment_variant = attachment.variant(
-        resize: ATTACHMENT_STYLES[style.to_sym],
-        strip: true,
-        'auto-orient': true,
-        colorspace: 'sRGB',
-      ).processed
-    end
-
-    attachment_variant.service_url(options)
+    Spree::ActiveStorageAttachment.attachment_variant(
+      attachment,
+      style: style,
+      default_style: default_style,
+      styles: ATTACHMENT_STYLES
+    )&.service_url(options)
   end
 
   def filename

--- a/core/app/models/spree/image/active_storage_attachment.rb
+++ b/core/app/models/spree/image/active_storage_attachment.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'active_storage'
+
+module Spree::Image::ActiveStorageAttachment
+  extend ActiveSupport::Concern
+
+  module IOAttachmentSupport
+    extend ActiveSupport::Concern
+
+    def attachment=(attachable)
+      case attachable
+      when ActiveStorage::Blob, ActionDispatch::Http::UploadedFile,
+           Rack::Test::UploadedFile, Hash, String
+        super
+      when ActiveStorage::Attached
+        super(attachable.blob)
+      else # assume it's an IO
+        if attachable.respond_to?(:to_path)
+          filename = attachable.to_path
+        else
+          filename = SecureRandom.uuid
+        end
+        attachable.rewind
+
+        super(
+          io: attachable,
+          filename: filename
+        )
+      end
+    end
+  end
+
+  included do
+    has_one_attached :attachment
+
+    validates :attachment, presence: true
+    validate :attachment_is_an_image
+
+    # This needs to be prepended in order to override the
+    # accessor (#attachment=) defined by ActiveStorage.
+    prepend IOAttachmentSupport
+  end
+
+  class_methods do
+    def attachment_definitions
+      { attachment: { styles: ATTACHMENT_STYLES } }
+    end
+  end
+
+  ATTACHMENT_STYLES = {
+    mini: '48x48>',
+    small: '100x100>',
+    product: '240x240>',
+    large: '600x600>',
+  }
+
+  def default_style
+    :original
+  end
+
+  def url(style = default_style, options = {})
+    return unless attachment && attachment.attachment
+
+    style = style.to_sym
+    options = normalize_url_options(options)
+
+    if style == default_style
+      attachment_variant = attachment
+    else
+      attachment_variant = attachment.variant(
+        resize: ATTACHMENT_STYLES[style.to_sym],
+        strip: true,
+        'auto-orient': true,
+        colorspace: 'sRGB',
+      ).processed
+    end
+
+    attachment_variant.service_url(options)
+  end
+
+  def filename
+    attachment.blob.filename.to_s
+  end
+
+  def attachment_width
+    attachment.metadata[:width]
+  end
+
+  def attachment_height
+    attachment.metadata[:height]
+  end
+
+  def attachment_present?
+    attachment.attached?
+  end
+
+  private
+
+  def attachment_is_an_image
+    errors.add :attachment, 'is not an image' unless attachment.try(:attachment).try(:image?)
+  end
+
+  def normalize_url_options(options)
+    if [true, false].include? options # Paperclip backwards compatibility.
+      Spree::Deprecation.warn(
+        "Using #{self.class}#url with true/false as second parameter is deprecated, if you "\
+        "want to enable/disable timestamps pass `timestamps: true` (or `false`)."
+      )
+      options = { timestamp: options }
+    end
+
+    options
+  end
+end

--- a/core/app/models/spree/image/active_storage_attachment.rb
+++ b/core/app/models/spree/image/active_storage_attachment.rb
@@ -16,7 +16,7 @@ module Spree::Image::ActiveStorageAttachment
           style: style,
           default_style: default_style,
           styles: ATTACHMENT_STYLES
-        )&.service_url(options)
+        )
       else
         # With 0 args will be ok, otherwise will raise an ArgumentError
         super

--- a/core/app/models/spree/image/paperclip_attachment.rb
+++ b/core/app/models/spree/image/paperclip_attachment.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Spree::Image::PaperclipAttachment
+  extend ActiveSupport::Concern
+
+  included do
+    validate :no_attachment_errors
+
+    has_attached_file :attachment,
+                      styles: { mini: '48x48>', small: '100x100>', product: '240x240>', large: '600x600>' },
+                      default_style: :product,
+                      default_url: 'noimage/:style.png',
+                      url: '/spree/products/:id/:style/:basename.:extension',
+                      path: ':rails_root/public/spree/products/:id/:style/:basename.:extension',
+                      convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
+    validates_attachment :attachment,
+      presence: true,
+      content_type: { content_type: %w[image/jpeg image/jpg image/png image/gif] }
+
+    # save the w,h of the original image (from which others can be calculated)
+    # we need to look at the write-queue for images which have not been saved yet
+    after_post_process :find_dimensions, if: :valid?
+  end
+
+  def url(size)
+    attachment.url(size)
+  end
+
+  def filename
+    attachment_file_name
+  end
+
+  def attachment_present?
+    attachment.present?
+  end
+
+  def find_dimensions
+    temporary = attachment.queued_for_write[:original]
+    filename = temporary.path unless temporary.nil?
+    filename = attachment.path if filename.blank?
+    geometry = Paperclip::Geometry.from_file(filename)
+    self.attachment_width  = geometry.width
+    self.attachment_height = geometry.height
+  end
+
+  # if there are errors from the plugin, then add a more meaningful message
+  def no_attachment_errors
+    unless attachment.errors.empty?
+      # uncomment this to get rid of the less-than-useful interim messages
+      # errors.clear
+      errors.add :attachment, "Paperclip returned errors for file '#{attachment_file_name}' - check ImageMagick installation or image source file."
+      false
+    end
+  end
+end

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -25,15 +25,22 @@ module Spree
     after_save :touch_ancestors_and_taxonomy
     after_touch :touch_ancestors_and_taxonomy
 
-    has_attached_file :icon,
-      styles: { mini: '32x32>', normal: '128x128>' },
-      default_style: :mini,
-      url: '/spree/taxons/:id/:style/:basename.:extension',
-      path: ':rails_root/public/spree/taxons/:id/:style/:basename.:extension',
-      default_url: '/assets/default_taxon.png'
+    if ::Spree::Config.taxon_attachment_module.blank?
+      Spree::Deprecation.warn <<-MESSAGE.strip_heredoc + "\n\n"
+        Using Paperclip as taxon_attachment_module for Taxon.
 
-    validates_attachment :icon,
-      content_type: { content_type: ["image/jpg", "image/jpeg", "image/png", "image/gif"] }
+        Please configure Spree::Config.taxon_attachment_module in your store
+        initializer.
+
+        To use the Paperclip adapter (default):
+          Spree.config do |config|
+            config.taxon_attachment_module = 'Spree::Taxon::PaperclipAttachment'
+          end
+      MESSAGE
+      ::Spree::Config.taxon_attachment_module = 'Spree::Taxon::PaperclipAttachment'
+    end
+
+    include ::Spree::Config.taxon_attachment_module.to_s.constantize
 
     # @note This method is meant to be overridden on a store by store basis.
     # @return [Array] filters that should be used for a taxon

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -32,7 +32,12 @@ module Spree
         Please configure Spree::Config.taxon_attachment_module in your store
         initializer.
 
-        To use the Paperclip adapter (default):
+        To use the ActiveStorage adapter (recommended):
+          Spree.config do |config|
+            config.image_attachment_module = 'Spree::Taxon::ActiveStorageAttachment'
+          end
+
+        To use the Paperclip adapter (legacy, deprecated):
           Spree.config do |config|
             config.taxon_attachment_module = 'Spree::Taxon::PaperclipAttachment'
           end

--- a/core/app/models/spree/taxon/active_storage_attachment.rb
+++ b/core/app/models/spree/taxon/active_storage_attachment.rb
@@ -4,50 +4,15 @@ require 'active_storage'
 
 module Spree::Taxon::ActiveStorageAttachment
   extend ActiveSupport::Concern
-
-  module IOAttachmentSupport
-    extend ActiveSupport::Concern
-
-    def icon=(attachable)
-      case attachable
-      when ActiveStorage::Blob, ActionDispatch::Http::UploadedFile,
-           Rack::Test::UploadedFile, Hash, String
-        super
-      when ActiveStorage::Attached
-        super(attachable.blob)
-      else # assume it's an IO
-        if attachable.respond_to?(:to_path)
-          filename = attachable.to_path
-        else
-          filename = SecureRandom.uuid
-        end
-        attachable.rewind
-
-        super(
-          io: attachable,
-          filename: filename
-        )
-      end
-    end
-  end
+  include Spree::ActiveStorageAttachment
 
   included do
     has_one_attached :icon
-
-    validate :icon_is_an_image
-
-    # This needs to be prepended in order to override the
-    # accessor (#icon=) defined by ActiveStorage.
-    prepend IOAttachmentSupport
+    redefine_attachment_writer_with_legacy_io_support :icon
+    validate_attachment_to_be_an_image :icon
   end
 
   def icon_present?
     icon.attached?
-  end
-
-  private
-
-  def icon_is_an_image
-    errors.add :icon, 'is not an image' unless icon.try(:attachment).try(:image?)
   end
 end

--- a/core/app/models/spree/taxon/active_storage_attachment.rb
+++ b/core/app/models/spree/taxon/active_storage_attachment.rb
@@ -10,6 +10,7 @@ module Spree::Taxon::ActiveStorageAttachment
     has_one_attached :icon
     redefine_attachment_writer_with_legacy_io_support :icon
     validate_attachment_to_be_an_image :icon
+    prepend Spree::DeprecatedPaperclipAPI
   end
 
   def icon_present?

--- a/core/app/models/spree/taxon/active_storage_attachment.rb
+++ b/core/app/models/spree/taxon/active_storage_attachment.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'active_storage'
+
+module Spree::Taxon::ActiveStorageAttachment
+  extend ActiveSupport::Concern
+
+  module IOAttachmentSupport
+    extend ActiveSupport::Concern
+
+    def icon=(attachable)
+      case attachable
+      when ActiveStorage::Blob, ActionDispatch::Http::UploadedFile,
+           Rack::Test::UploadedFile, Hash, String
+        super
+      when ActiveStorage::Attached
+        super(attachable.blob)
+      else # assume it's an IO
+        if attachable.respond_to?(:to_path)
+          filename = attachable.to_path
+        else
+          filename = SecureRandom.uuid
+        end
+        attachable.rewind
+
+        super(
+          io: attachable,
+          filename: filename
+        )
+      end
+    end
+  end
+
+  included do
+    has_one_attached :icon
+
+    validate :icon_is_an_image
+
+    # This needs to be prepended in order to override the
+    # accessor (#icon=) defined by ActiveStorage.
+    prepend IOAttachmentSupport
+  end
+
+  def icon_present?
+    icon.attached?
+  end
+
+  private
+
+  def icon_is_an_image
+    errors.add :icon, 'is not an image' unless icon.try(:attachment).try(:image?)
+  end
+end

--- a/core/app/models/spree/taxon/paperclip_attachment.rb
+++ b/core/app/models/spree/taxon/paperclip_attachment.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Spree::Taxon::PaperclipAttachment
+  extend ActiveSupport::Concern
+
+  included do
+    has_attached_file :icon,
+      styles: { mini: '32x32>', normal: '128x128>' },
+      default_style: :mini,
+      url: '/spree/taxons/:id/:style/:basename.:extension',
+      path: ':rails_root/public/spree/taxons/:id/:style/:basename.:extension',
+      default_url: '/assets/default_taxon.png'
+
+    validates_attachment :icon,
+      content_type: { content_type: %w[image/jpg image/jpeg image/png image/gif] }
+  end
+
+  def icon_present?
+    icon.present?
+  end
+end

--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb.tt
@@ -19,18 +19,11 @@ Spree.config do |config|
   # config.inventory_cache_threshold = 3
 
   <% if defined? ::ActiveStorage %>
-  # Enable ActiveStorage attachments on images, requires:
+  # Enable ActiveStorage attachments on images and taxons, requires:
   #
   #   bin/rails active_storage:install
   #
-  # (To use the legacy Paperclip implementation just comment the following line)
   config.image_attachment_module = 'Spree::Image::ActiveStorageAttachment'
-
-  # Enable ActiveStorage attachments on images, requires:
-  #
-  #   bin/rails active_storage:install
-  #
-  # (To use the legacy Paperclip implementation just comment the following line)
   config.taxon_attachment_module = 'Spree::Taxon::ActiveStorageAttachment'
 
   <% end %>

--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb.tt
@@ -26,6 +26,13 @@ Spree.config do |config|
   # (To use the legacy Paperclip implementation just comment the following line)
   config.image_attachment_module = 'Spree::Image::ActiveStorageAttachment'
 
+  # Enable ActiveStorage attachments on images, requires:
+  #
+  #   bin/rails active_storage:install
+  #
+  # (To use the legacy Paperclip implementation just comment the following line)
+  config.taxon_attachment_module = 'Spree::Taxon::ActiveStorageAttachment'
+
   <% end %>
 
   # Frontend:

--- a/core/lib/generators/spree/install/templates/config/initializers/spree.rb.tt
+++ b/core/lib/generators/spree/install/templates/config/initializers/spree.rb.tt
@@ -18,6 +18,15 @@ Spree.config do |config|
   # any inventory changes.
   # config.inventory_cache_threshold = 3
 
+  <% if defined? ::ActiveStorage %>
+  # Enable ActiveStorage attachments on images, requires:
+  #
+  #   bin/rails active_storage:install
+  #
+  # (To use the legacy Paperclip implementation just comment the following line)
+  config.image_attachment_module = 'Spree::Image::ActiveStorageAttachment'
+
+  <% end %>
 
   # Frontend:
 

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -437,6 +437,16 @@ module Spree
     # Enumerable of images adhering to the present_image_class interface
     preference :image_attachment_module, default: nil
 
+    # Allows switching attachment library for Taxon
+    #
+    # `Spree::Taxon::PaperclipAttachment`
+    # is the default and provides the classic Paperclip implementation.
+    #
+    # @!attribute [rw] taxon_attachment_module
+    # @return [Module] a module that can be included into Spree::Taxon to allow attachments
+    # Enumerable of taxons adhering to the present_taxon_class interface
+    preference :taxon_attachment_module, default: nil
+
     # Allows providing your own class instance for generating order numbers.
     #
     # @!attribute [rw] order_number_generator

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -423,6 +423,13 @@ module Spree
     # Enumerable of images adhering to the present_image_class interface
     class_name_attribute :product_gallery_class, default: 'Spree::Gallery::ProductGallery'
 
+    # Allows switching attachment library for Image
+    #
+    # @!attribute [rw] image_attachment_module
+    # @return [Module] a module that can be included into Spree::Image to allow attachments
+    # Enumerable of images adhering to the present_image_class interface
+    preference :image_attachment_module, default: nil
+
     # Allows providing your own class instance for generating order numbers.
     #
     # @!attribute [rw] order_number_generator

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -425,6 +425,13 @@ module Spree
 
     # Allows switching attachment library for Image
     #
+    # `Spree::Image::PaperclipAttachment`
+    # is the default and provides the classic Paperclip implementation.
+    #
+    # `Spree::Image::ActiveStorageAttachment`
+    # Is the new ActiveStorage implementation, requires `bin/rails active_storage:install` in
+    # order to work.
+    #
     # @!attribute [rw] image_attachment_module
     # @return [Module] a module that can be included into Spree::Image to allow attachments
     # Enumerable of images adhering to the present_image_class interface

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -442,6 +442,10 @@ module Spree
     # `Spree::Taxon::PaperclipAttachment`
     # is the default and provides the classic Paperclip implementation.
     #
+    # `Spree::Taxon::ActiveStorageAttachment`
+    # Is the new ActiveStorage implementation, requires `bin/rails active_storage:install` in
+    # order to work.
+    #
     # @!attribute [rw] taxon_attachment_module
     # @return [Module] a module that can be included into Spree::Taxon to allow attachments
     # Enumerable of taxons adhering to the present_taxon_class interface

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -12,14 +12,11 @@ Rails.env = 'test'
 
 require 'solidus_core'
 
-# @private
-def forgery_protected_by_default?
-  Gem::Version.new(Rails.version) >= Gem::Version.new('5.2')
-end
+RAILS_52_OR_ABOVE = Gem::Version.new(Rails.version) >= Gem::Version.new('5.2')
 
 # @private
 class ApplicationController < ActionController::Base
-  if !forgery_protected_by_default?
+  unless RAILS_52_OR_ABOVE
     protect_from_forgery with: :exception
   end
 end
@@ -65,12 +62,8 @@ module DummyApp
     config.active_support.deprecation                 = :stderr
     config.secret_key_base                            = 'SECRET_TOKEN'
 
-    if forgery_protected_by_default?
+    if RAILS_52_OR_ABOVE
       config.action_controller.default_protect_from_forgery = true
-    end
-
-    if config.active_record.sqlite3
-      # Rails >= 5.2
       config.active_record.sqlite3.represent_boolean_as_integer = true
     end
 

--- a/core/lib/spree/testing_support/dummy_app.rb
+++ b/core/lib/spree/testing_support/dummy_app.rb
@@ -111,10 +111,12 @@ Spree.user_class = 'Spree::LegacyUser'
 Spree.config do |config|
   config.mails_from = "store@example.com"
 
-  config.image_attachment_module = if ENV['ACTIVE_STORAGE']
-    'Spree::Image::ActiveStorageAttachment'
+  if ENV['ACTIVE_STORAGE']
+    config.image_attachment_module = 'Spree::Image::ActiveStorageAttachment'
+    config.taxon_attachment_module = 'Spree::Taxon::ActiveStorageAttachment'
   else
-    'Spree::Image::PaperclipAttachment'
+    config.image_attachment_module = 'Spree::Image::PaperclipAttachment'
+    config.taxon_attachment_module = 'Spree::Taxon::PaperclipAttachment'
   end
 end
 

--- a/core/lib/spree/testing_support/dummy_app/migrations.rb
+++ b/core/lib/spree/testing_support/dummy_app/migrations.rb
@@ -32,6 +32,10 @@ module DummyApp
 
         sh 'rake db:reset VERBOSE=false'
 
+        if ENV['ACTIVE_STORAGE']
+          sh 'rake active_storage:install db:migrate VERBOSE=false'
+        end
+
         # We have a brand new database, so we must re-establish our connection
         ActiveRecord::Base.establish_connection
       end

--- a/core/lib/spree/testing_support/preferences.rb
+++ b/core/lib/spree/testing_support/preferences.rb
@@ -19,10 +19,12 @@ module Spree
         end
 
         ::Spree.config do |config|
-          config.image_attachment_module = if ENV['ACTIVE_STORAGE']
-            'Spree::Image::ActiveStorageAttachment'
+          if ENV['ACTIVE_STORAGE']
+            config.image_attachment_module = 'Spree::Image::ActiveStorageAttachment'
+            config.taxon_attachment_module = 'Spree::Taxon::ActiveStorageAttachment'
           else
-            'Spree::Image::PaperclipAttachment'
+            config.image_attachment_module = 'Spree::Image::PaperclipAttachment'
+            config.taxon_attachment_module = 'Spree::Taxon::PaperclipAttachment'
           end
         end
 

--- a/core/lib/spree/testing_support/preferences.rb
+++ b/core/lib/spree/testing_support/preferences.rb
@@ -18,6 +18,14 @@ module Spree
           Rails.application.config.spree = Spree::Config.environment
         end
 
+        ::Spree.config do |config|
+          config.image_attachment_module = if ENV['ACTIVE_STORAGE']
+            'Spree::Image::ActiveStorageAttachment'
+          else
+            'Spree::Image::PaperclipAttachment'
+          end
+        end
+
         configure_spree_preferences(&config_block) if block_given?
       end
 

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'carmen', '~> 1.1.0'
   s.add_dependency 'discard', '~> 1.0'
   s.add_dependency 'friendly_id', '~> 5.0'
+  s.add_dependency 'image_processing', '~> 1.2'
   s.add_dependency 'kaminari-activerecord', '~> 1.1'
   s.add_dependency 'monetize', '~> 1.8'
   s.add_dependency 'paperclip', ['>= 4.2', '< 6']


### PR DESCRIPTION
The module has been extracted in order to simplify inclusion in multiple models. 

Also, a few more `Paperclip` API methods have been added to the module to simplify the upgrade to `ActiveStorage`.