### PR TITLE
Introduce deprecation warning when using `Spree::Refund#perform!` callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ### Backend
 
+**Added Spree::Event**
+
+Solidus now includes an event library that allows to use different adapters.
+The default adapter is based on `ActiveSupport::Notifications` library.
+Events should allow developers to customize and extend Solidus behavior
+more easily by simply subscribing to certain events. Sending emails may be a
+simple use case for this new feature.
+
 ### API
 
 ### Frontend

--- a/api/app/controllers/spree/api/shipments_controller.rb
+++ b/api/app/controllers/spree/api/shipments_controller.rb
@@ -131,11 +131,8 @@ module Spree
       end
 
       def find_order_on_create
-        # TODO: Can remove conditional here once deprecated #find_order is removed.
-        unless @order.present?
-          @order = Spree::Order.find_by!(number: params[:shipment][:order_id])
-          authorize! :read, @order
-        end
+        @order = Spree::Order.find_by!(number: params[:shipment][:order_id])
+        authorize! :read, @order
       end
 
       def find_shipment

--- a/backend/spec/features/admin/orders/new_refund_spec.rb
+++ b/backend/spec/features/admin/orders/new_refund_spec.rb
@@ -12,12 +12,16 @@ RSpec.describe 'New Refund creation', :js do
 
   it 'creates a new refund' do
     visit spree.new_admin_order_payment_refund_path(order, payment)
+
     expect(page).not_to have_selector 'td', text: amount
+    expect(Spree::Deprecation).to receive(:warn)
+
     within '.new_refund' do
       fill_in 'refund_amount', with: amount
       select reason.name, from: 'Reason'
       click_button 'Refund'
     end
+
     expect(page).to have_content 'Refund has been successfully created!'
     expect(page).to have_selector 'td', text: amount
   end
@@ -25,6 +29,7 @@ RSpec.describe 'New Refund creation', :js do
   it 'disables the button at submit' do
     visit spree.new_admin_order_payment_refund_path(order, payment)
     page.execute_script "$('form').submit(function(e) { e.preventDefault()})"
+
     within '.new_refund' do
       fill_in 'refund_amount', with: amount
       select reason.name, from: 'Reason'

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -47,7 +47,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new
   browser_options.args << '--headless'
   browser_options.args << '--disable-gpu'
-  browser_options.args << '--window-size=1440,1080'
+  browser_options.args << '--window-size=1920,1080'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -434,18 +434,13 @@ module Spree
 
       touch :completed_at
 
-      deliver_order_confirmation_email unless confirmation_delivered?
+      Spree::Event.fire 'order_finalized', order: self
     end
 
     def fulfill!
       shipments.each { |shipment| shipment.update_state if shipment.persisted? }
       updater.update_shipment_state
       save!
-    end
-
-    def deliver_order_confirmation_email
-      Spree::Config.order_mailer_class.confirm_email(self).deliver_later
-      update_column(:confirmation_delivered, true)
     end
 
     # Helper methods for checkout steps

--- a/core/app/models/spree/payment/cancellation.rb
+++ b/core/app/models/spree/payment/cancellation.rb
@@ -31,7 +31,7 @@ module Spree
           if response = payment.payment_method.try_void(payment)
             payment.send(:handle_void_response, response)
           else
-            payment.refunds.create!(amount: payment.credit_allowed, reason: refund_reason)
+            payment.refunds.create!(amount: payment.credit_allowed, reason: refund_reason, perform_after_creation: false)
           end
         else
           # For payment methods not yet implemeting `try_void`

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -8,6 +8,8 @@ module Spree
 
     has_many :log_entries, as: :source
 
+    attr_writer :perform_after_creation
+
     validates :payment, presence: true
     validates :reason, presence: true
     validates :transaction_id, presence: true, on: :update # can't require this on create because the before_create needs to run first
@@ -39,9 +41,18 @@ module Spree
 
     private
 
+    def perform_after_creation
+      return true if @perform_after_creation.nil?
+      @perform_after_creation
+    end
+
     # attempts to perform the refund.
     # raises an error if the refund fails.
     def perform!
+      if perform_after_creation
+        Spree::Deprecation.warn('From Solidus v3.0 onwards, #perform! will need to be explicitly called.')
+      end
+
       return true if transaction_id.present?
 
       credit_cents = money.cents

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -111,11 +111,15 @@ module Spree
 
       if unpaid_amount_within_tolerance?
         reimbursed!
+        Spree::Event.fire 'reimbursement_reimbursed', reimbursement: self
         reimbursement_success_hooks.each { |h| h.call self }
-        send_reimbursement_email
       else
         errored!
+        Spree::Event.fire 'reimbursement_errored', reimbursement: self
         reimbursement_failure_hooks.each { |h| h.call self }
+      end
+
+      if errored?
         raise IncompleteReimbursementError, I18n.t("spree.validation.unpaid_amount_not_zero", amount: unpaid_amount)
       end
     end
@@ -174,10 +178,6 @@ module Spree
       if return_items.any? { |ri| ri.inventory_unit.order_id != order_id }
         errors.add(:base, :return_items_order_id_does_not_match)
       end
-    end
-
-    def send_reimbursement_email
-      Spree::Config.reimbursement_mailer_class.reimbursement_email(id).deliver_later
     end
 
     # If there are multiple different reimbursement types for a single

--- a/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
+++ b/core/app/models/spree/reimbursement_type/reimbursement_helpers.rb
@@ -34,7 +34,8 @@ module Spree
       refund = reimbursement.refunds.build({
         payment: payment,
         amount: amount,
-        reason: Spree::RefundReason.return_processing_reason
+        reason: Spree::RefundReason.return_processing_reason,
+        perform_after_creation: false
       })
 
       simulate ? refund.readonly! : refund.save!

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -449,6 +449,10 @@ module Spree
       end
     end
 
+    def events
+      @events_configuration ||= Spree::Event::Configuration.new
+    end
+
     def environment
       @environment ||= Spree::Core::Environment.new(self).tap do |env|
         env.calculators.shipping_methods = %w[

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -63,6 +63,7 @@ require 'spree/core/environment'
 require 'spree/promo/environment'
 require 'spree/migrations'
 require 'spree/migration_helpers'
+require 'spree/event'
 require 'spree/core/engine'
 
 require 'spree/i18n'

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spree/config'
+require 'spree/event/processors/mailer_processor'
 
 module Spree
   module Core
@@ -42,6 +43,10 @@ module Spree
 
       initializer "spree.core.checking_migrations", before: :load_config_initializers do |_app|
         Migrations.new(config, engine_name).check
+      end
+
+      initializer 'spree.core.subscribe_event_mailer_processor' do
+        Spree::Event::Processors::MailerProcessor.subscribe!
       end
 
       # Load in mailer previews for apps to use in development.

--- a/core/lib/spree/event.rb
+++ b/core/lib/spree/event.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require_relative 'event/adapters/active_support_notifications'
+require_relative 'event/configuration'
+require_relative 'event/subscriber'
+
+module Spree
+  module Event
+    extend self
+
+    # Allows to trigger events that can be subscribed using #subscribe. An
+    # optional block can be passed that will be executed immediately. The
+    # actual code implementation is delegated to the adapter.
+    #
+    # @param [String] event_name the name of the event. The suffix ".spree"
+    #  will be added automatically if not present
+    # @param [Hash] opts a list of options to be passed to the triggered event
+    #
+    # @example Trigger an event named 'order_finalized'
+    #   Spree::Event.fire 'order_finalized', order: @order do
+    #     @order.finalize!
+    #   end
+    def fire(event_name, opts = {})
+      adapter.fire name_with_suffix(event_name), opts do
+        yield opts if block_given?
+      end
+    end
+
+    # Subscribe to an event with the given name. The provided block is executed
+    # every time the subscribed event is fired.
+    #
+    # @param [String] event_name the name of the event. The suffix ".spree"
+    #  will be added automatically if not present
+    #
+    # @return a subscription object that can be used as reference in order
+    #  to remove the subscription
+    #
+    # @example Subscribe to the `order_finalized` event
+    #   Spree::Event.subscribe 'order_finalized' do |event|
+    #     order = event.payload[:order]
+    #     Spree::Mailer.order_finalized(order).deliver_later
+    #   end
+    #
+    # @see Spree::Event#unsubscribe
+    def subscribe(event_name, &block)
+      name = name_with_suffix(event_name)
+      listener_names << name
+      adapter.subscribe(name, &block)
+    end
+
+    # Unsubscribes a whole event or a specific subscription object
+    #
+    # @param [String, Object] subscriber the event name as a string (with
+    #  or without the ".spree" suffix) or the subscription object
+    #
+    # @example Unsubscribe a single subscription
+    #   subscription = Spree::Event.fire 'order_finalized'
+    #   Spree::Event.unsubscribe(subscription)
+    # @example Unsubscribe all `order_finalized` event subscriptions
+    #   Spree::Event.unsubscribe('order_finalized')
+    # @example Unsubscribe an event by name with explicit prefix
+    #   Spree::Event.unsubscribe('order_finalized.spree')
+    def unsubscribe(subscriber)
+      name_or_subscriber = subscriber.is_a?(String) ? name_with_suffix(subscriber) : subscriber
+      adapter.unsubscribe(name_or_subscriber)
+    end
+
+    # Lists all subscriptions currently registered under the ".spree"
+    # namespace. Actual implementation is delegated to the adapter
+    #
+    # @return [Hash] an hash with event names as keys and arrays of subscriptions
+    #  as values
+    #
+    # @example Current subscriptions
+    #  Spree::Event.listeners
+    #    # => {"order_finalized.spree"=> [#<ActiveSupport...>],
+    #      "reimbursement_reimbursed.spree"=> [#<ActiveSupport...>]}
+    def listeners
+      adapter.listeners_for(listener_names)
+    end
+
+    # The adapter used by Spree::Event, defaults to
+    # Spree::Event::Adapters::ActiveSupportNotifications
+    #
+    # @example Change the adapter
+    #   Spree::Config.events.adapter = "Spree::EventBus.new"
+    #
+    # @see Spree::AppConfiguration
+    def adapter
+      Spree::Config.events.adapter
+    end
+
+    # The suffix used for namespacing Solidus events, defaults to
+    # `.spree`
+    #
+    # @see Spree::Event::Configuration#suffix
+    def suffix
+      Spree::Config.events.suffix
+    end
+
+    private
+
+    def name_with_suffix(name)
+      name.end_with?(suffix) ? name : [name, suffix].join
+    end
+
+    def listener_names
+      @listeners_names ||= Set.new
+    end
+  end
+end

--- a/core/lib/spree/event/adapters/active_support_notifications.rb
+++ b/core/lib/spree/event/adapters/active_support_notifications.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Spree
+  module Event
+    module Adapters
+      module ActiveSupportNotifications
+        extend self
+
+        def fire(event_name, opts)
+          ActiveSupport::Notifications.instrument event_name, opts do
+            yield opts if block_given?
+          end
+        end
+
+        def subscribe(event_name)
+          ActiveSupport::Notifications.subscribe event_name do |*args|
+            event = ActiveSupport::Notifications::Event.new(*args)
+            yield event
+          end
+        end
+
+        def unsubscribe(subscriber_or_name)
+          ActiveSupport::Notifications.unsubscribe(subscriber_or_name)
+        end
+
+        def listeners_for(names)
+          names.each_with_object({}) do |name, memo|
+            listeners = ActiveSupport::Notifications.notifier.listeners_for(name)
+            memo[name] = listeners if listeners.present?
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/event/configuration.rb
+++ b/core/lib/spree/event/configuration.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Spree
+  module Event
+    class Configuration
+      attr_writer :adapter, :suffix
+
+      def adapter
+        @adapter ||= Spree::Event::Adapters::ActiveSupportNotifications
+      end
+
+      def suffix
+        @suffix ||= '.spree'
+      end
+    end
+  end
+end

--- a/core/lib/spree/event/processors/mailer_processor.rb
+++ b/core/lib/spree/event/processors/mailer_processor.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Spree
+  module Event
+    module Processors
+      module MailerProcessor
+        include Spree::Event::Subscriber
+
+        event_action :order_finalized
+        event_action :send_reimbursement_email, event_name: :reimbursement_reimbursed
+
+        def order_finalized(event)
+          order = event.payload[:order]
+          unless order.confirmation_delivered?
+            Spree::Config.order_mailer_class.confirm_email(order).deliver_later
+            order.update_column(:confirmation_delivered, true)
+          end
+        end
+
+        def send_reimbursement_email(event)
+          reimbursement = event.payload[:reimbursement]
+          Spree::Config.reimbursement_mailer_class.reimbursement_email(reimbursement.id).deliver_later
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/event/subscriber.rb
+++ b/core/lib/spree/event/subscriber.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Spree
+  module Event
+    # This module simplifies adding and removing subscriptions to {Spree::Event} events.
+    # Here's a complete example:
+    #   module EmailSender
+    #     include Spree::Event::Subscriber
+    #
+    #     event_action :order_finalized
+    #     event_action :confirm_reimbursement, event_name: :reimbursement_reimbursed
+    #
+    #     def order_finalized(event)
+    #       Mailer.send_email(event.payload[:order])
+    #     end
+    #
+    #     def confirm_reimbursement(event)
+    #       Mailer.send_email(event.payload[:reimbursement])
+    #     end
+    #   end
+    #
+    #  EmailSender.subscribe!
+    module Subscriber
+      def self.included(base)
+        base.extend base
+
+        base.mattr_accessor :event_actions
+        base.event_actions = {}
+      end
+
+      # Declares a method name in the including module that can be subscribed/unsubscribed
+      # to an event.
+      #
+      # @param method_name [String, Symbol] the method that will be called when the subscribed event is fired
+      # @param event_name [String, Symbol] the name of the event to be subscribed
+      #
+      # @example Declares 'send_email' as an event action that can subscribe the event 'order_finalized'
+      #   module EmailSender
+      #     event_action :send_email, event_name: :order_finalized
+      #
+      #     def send_email(event)
+      #       Mailer.send_email(event.payload[:order])
+      #     end
+      #   end
+      #
+      # @example Same as above, but the method name is same as the event name:
+      #   module EmailSender
+      #     event_action :order_completed
+      #
+      #     def order_completed(event)
+      #       Mailer.send_email(event.payload[:order])
+      #     end
+      #   end
+      def event_action(method_name, event_name: nil)
+        mattr_accessor "#{method_name}_handler"
+        event_actions[method_name] = (event_name || method_name).to_s
+      end
+
+      # Subscribes all declared event actions to their events. Only actions that are subscribed
+      # will be called when their event fires.
+      #
+      # @example subscribe all event actions for module 'EmailSender'
+      #    EmailSender.subscribe!
+      def subscribe!
+        unsubscribe!
+        event_actions.each do |event_action, event_name|
+          send "#{event_action}_handler=", Spree::Event.subscribe(event_name) { |event|
+            send event_action, event
+          }
+        end
+      end
+
+      # Unsubscribes all declared event actions from their events. This means that when an event
+      # fires then none of its unsubscribed event actions will be called.
+      # @example unsubscribe all event actions for module 'EmailSender'
+      #    EmailSender.unsubscribe!
+      def unsubscribe!
+        event_actions.keys.each do |event_action|
+          Spree::Event.unsubscribe send("#{event_action}_handler")
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories/refund_factory.rb
+++ b/core/lib/spree/testing_support/factories/refund_factory.rb
@@ -12,10 +12,13 @@ FactoryBot.define do
     end
 
     amount { 100.00 }
+    perform_after_creation { false }
     transaction_id { generate(:refund_transaction_id) }
+
     payment do
       association(:payment, state: 'completed', amount: payment_amount)
     end
+
     association(:reason, factory: :refund_reason)
   end
 end

--- a/core/spec/lib/spree/event/subscriber_spec.rb
+++ b/core/spec/lib/spree/event/subscriber_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'spree/event'
+
+RSpec.describe Spree::Event do
+  module M
+    include Spree::Event::Subscriber
+
+    event_action :event_name
+
+    def event_name(event)
+      # code that handles the event
+    end
+
+    def other_event(event)
+      # ...
+    end
+  end
+
+  describe '::subscribe!' do
+    before { M.unsubscribe! }
+
+    it 'adds new listeners to Spree::Event' do
+      expect { M.subscribe! }.to change { Spree::Event.listeners }
+    end
+
+    context 'when subscriptions are not registered' do
+      it 'does not trigger the event callback' do
+        expect(M).not_to receive(:event_name)
+        Spree::Event.fire 'event_name'
+      end
+    end
+
+    it 'subscribes event actions' do
+      M.subscribe!
+      expect(M).to receive(:event_name)
+      Spree::Event.fire 'event_name'
+    end
+
+    it 'does not subscribe event actions more than once' do
+      2.times { M.subscribe! }
+      expect(M).to receive(:event_name).once
+      Spree::Event.fire 'event_name'
+    end
+  end
+
+  describe '::unsubscribe' do
+    before { M.subscribe! }
+
+    it 'removes the subscription' do
+      expect(M).not_to receive(:event_name)
+      M.unsubscribe!
+      Spree::Event.fire 'event_name'
+    end
+  end
+
+  describe '::event_action' do
+    context 'when the action has not been declared' do
+      before { M.subscribe! }
+
+      it 'does not subscribe the action' do
+        expect(M).not_to receive(:other_event)
+        Spree::Event.fire 'other_event'
+      end
+    end
+
+    context 'when the action is declared' do
+      before do
+        M.event_action :other_event
+        M.subscribe!
+      end
+
+      after do
+        M.unsubscribe!
+        M.event_actions.delete(:other_event)
+      end
+
+      it 'subscribe the action' do
+        expect(M).to receive(:other_event)
+        Spree::Event.fire 'other_event'
+      end
+    end
+  end
+end

--- a/core/spec/lib/spree/event_spec.rb
+++ b/core/spec/lib/spree/event_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'spree/event'
+
+RSpec.describe Spree::Event do
+  let(:subscription_name) { 'foo_bar' }
+  let(:item) { spy('object') }
+  let(:notifier) { ActiveSupport::Notifications.notifier }
+
+  subject { described_class }
+
+  it 'has default adapter' do
+    expect(subject.adapter).to eql Spree::Event::Adapters::ActiveSupportNotifications
+  end
+
+  before do
+    # ActiveSupport::Notifications does not provide an interface to clean all
+    # subscribers at once, so some low level brittle code is required
+    @old_subscribers = notifier.instance_variable_get('@subscribers').dup
+    @old_listeners = notifier.instance_variable_get('@listeners_for').dup
+    notifier.instance_variable_get('@subscribers').clear
+    notifier.instance_variable_get('@listeners_for').clear
+  end
+
+  after do
+    notifier.instance_variable_set '@subscribers', @old_subscribers
+    notifier.instance_variable_set '@listeners_for', @old_listeners
+  end
+
+  context 'with the default adapter' do
+    describe '#listeners' do
+      context 'when there is no subscription' do
+        it { expect(subject.listeners).to be_empty }
+
+        context 'after adding a subscription' do
+          before do
+            Spree::Event.subscribe(subscription_name) { item.do_something }
+          end
+
+          it 'includes the new subscription with custom suffix' do
+            expect(subject.listeners).to be_present
+            subscription_listeners = subject.listeners["#{subscription_name}.spree"]
+            expect(subscription_listeners).to be_a Array
+            expect(subscription_listeners.first).to be_a ActiveSupport::Notifications::Fanout::Subscribers::Timed
+          end
+        end
+      end
+    end
+
+    context 'subscriptions' do
+      describe '#subscribe' do
+        it 'can subscribe to events' do
+          Spree::Event.subscribe(subscription_name) { item.do_something }
+          Spree::Event.fire subscription_name
+          expect(item).to have_received :do_something
+        end
+      end
+
+      describe '#unsubscribe' do
+        context 'when unsubscribing using a subscription object as reference' do
+          let!(:subscription) { Spree::Event.subscribe(subscription_name) { item.do_something } }
+
+          before do
+            Spree::Event.subscribe(subscription_name) { item.do_something_else }
+          end
+
+          it 'can unsubscribe from single event by object' do
+            subject.unsubscribe subscription
+            Spree::Event.fire subscription_name
+            expect(item).not_to have_received :do_something
+            expect(item).to have_received :do_something_else
+          end
+        end
+
+        context 'when unsubscribing using a string as reference' do
+          before do
+            Spree::Event.subscribe(subscription_name) { item.do_something }
+            Spree::Event.subscribe(subscription_name) { item.do_something_else }
+          end
+
+          it 'can unsubscribe from multiple events with the same name' do
+            subject.unsubscribe subscription_name
+            Spree::Event.fire subscription_name
+            expect(item).not_to have_received :do_something
+            expect(item).not_to have_received :do_something_else
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -52,4 +52,8 @@ RSpec.describe Spree::AppConfiguration, type: :model do
     expect(prefs.admin_vat_location.state_id).to eq(nil)
     expect(prefs.admin_vat_location.country_id).to eq(nil)
   end
+
+  it 'has default Event adapter' do
+    expect(prefs.events.adapter).to eq Spree::Event::Adapters::ActiveSupportNotifications
+  end
 end

--- a/core/spec/models/spree/order/finalizing_spec.rb
+++ b/core/spec/models/spree/order/finalizing_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Spree::Order, type: :model do
     end
 
     it "should not send duplicate confirmation emails" do
-      allow(order).to receive_messages(confirmation_delivered?: true)
+      order.update(confirmation_delivered: true)
       expect(Spree::OrderMailer).not_to receive(:confirm_email)
       order.finalize!
     end

--- a/core/spec/models/spree/payment/cancellation_spec.rb
+++ b/core/spec/models/spree/payment/cancellation_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Spree::Payment::Cancellation do
           before do
             payment.refunds.create!(
               amount: credit_amount,
-              reason: Spree::RefundReason.where(name: 'test').first_or_create
+              reason: Spree::RefundReason.where(name: 'test').first_or_create,
+              perform_after_creation: false
             )
           end
 

--- a/core/spec/models/spree/reimbursement_spec.rb
+++ b/core/spec/models/spree/reimbursement_spec.rb
@@ -154,7 +154,8 @@ RSpec.describe Spree::Reimbursement, type: :model do
     context 'when reimbursement cannot be fully performed' do
       let!(:non_return_refund) { create(:refund, amount: 1, payment: payment) }
 
-      it 'raises IncompleteReimbursement error' do
+      it 'does not send a reimbursement email and raises IncompleteReimbursement error' do
+        expect(Spree::ReimbursementMailer).not_to receive(:reimbursement_email)
         expect { subject }.to raise_error(Spree::Reimbursement::IncompleteReimbursementError)
       end
     end
@@ -168,7 +169,7 @@ RSpec.describe Spree::Reimbursement, type: :model do
       end
     end
 
-    it "triggers the reimbursement mailer to be sent" do
+    it "triggers the reimbursement mailer to be sent via subscribed event" do
       expect(Spree::ReimbursementMailer).to receive(:reimbursement_email).with(reimbursement.id) { double(deliver_later: true) }
       subject
     end

--- a/guides/data/nav/developers.yml
+++ b/guides/data/nav/developers.yml
@@ -50,6 +50,10 @@
         href: "/developers/extensions/writing-extensions.html"
       - title: "Testing extensions"
         href: "/developers/extensions/testing-extensions.html"
+  - title: "Events"
+    dropdown:
+      - title: "Overview"
+        href: "/developers/events/overview.html"
   - title: "Inventory"
     dropdown:
       - title: "Overview"

--- a/guides/source/developers/adjustments/overview.html.md
+++ b/guides/source/developers/adjustments/overview.html.md
@@ -137,20 +137,20 @@ If you want to retrieve the line item adjustments, you can use the
 `line_item_adjustments` method:
 
 ```ruby
-Spree::Order.line_item_adjustments
+Spree::Order.find(1).line_item_adjustments
 ```
 
 Or, if you want to retrieve the shipment adjustments, you can use the
 `shipment_adjustments` method:
 
 ```ruby
-Spree::Order.shipment_adjustments
+Spree::Order.find(1).shipment_adjustments
 ```
 
 Finally, if you want to retrieve all of the adjustments on the order, you can
 use the `all_adjustments` method.
 
 ```ruby
-Spree::Order.all_adjustments
+Spree::Order.find(1).all_adjustments
 ```
 

--- a/guides/source/developers/events/overview.html.md
+++ b/guides/source/developers/events/overview.html.md
@@ -1,0 +1,54 @@
+# Events
+
+The `Spree::Event` module allows to fire and subscribe events inside Solidus codebase and extensions.
+
+The module can use different adapters that actually manage events at low level, the default adapter is Rails `ActiveSupport::Notification`. Future releases may include other adapters.
+
+Among other uses, Solidus codebase uses events in order to send confirmation emails when an order is finalized, or again to send emails when an order is refunded successfully.
+
+Events make easy extending Solidus with custom behavior. For example, if besides the standard email you also want to send a SMS text message to the customer when a order is finalized, this pseudo-code may do the trick:
+
+```ruby
+Spree::Event.subscribe 'order_finalized' do |event|
+  order = event.payload[:order]
+  SmsLibrary.deliver(order, :finalized)
+end
+```
+
+## Changing the adapter
+
+The adapter can be changed using this code, for example in a initializer:
+
+```ruby
+Spree::Config.events.adapter = "Spree::EventBus.new"
+```
+
+## Subscribing to events
+
+`Spree::Event.subscribe` allows to subscribe to a certain event. The event name is mandatory, the optional block will be executed everytime the event is fired:
+
+```ruby
+Spree::Event.subscribe 'order_finalized' do |event|
+  order = event.payload[:order]
+  Spree::Mailer.order_finalized(order).deliver_later
+end
+```
+
+## Firing events
+
+`Spree::Event.fire` allows to fire an event. The event name is mandatory, then both a hash of options (it will be available as the event payload) and an optional code block can be passed:
+
+```ruby
+Spree::Event.fire 'order_finalized', order: @order do
+  @order.finalize!
+end
+```
+
+This is an alternative way to basically have the same functionality but without the block:
+
+```ruby
+@order.finalize!
+Spree::Event.fire 'order_finalized', order: @order
+```
+
+For further information, please refer to the RDOC documentation included in the `Spree::Event` module.


### PR DESCRIPTION
**Description**

This PR introduces a deprecation warning when relying on `Spree::Refund#perform!` implicitly (i.e.: calling it as a callback rather than calling it explicitly); aims to serve as a starting point for #1415

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
