### PR TITLE
Add a search interface for orders on an user's admin page

### DIFF
--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -101,10 +101,10 @@
   </div>
 <% end %>
 
+<%= paginate @orders, theme: "solidus_admin" %>
+
 <fieldset data-hook="admin_user_order_history" class="no-border-bottom">
   <legend><%= t("spree.admin.user.order_history") %></legend>
-
-  <%= paginate @orders, theme: "solidus_admin" %>
 
   <% if @orders.any? %>
     <table class="index" id="listing_orders" data-hook>
@@ -170,6 +170,6 @@
                    new_resource_url: spree.new_admin_order_path(user_id: @user.id) %>
     </div>
   <% end %>
-
-  <%= paginate @orders, theme: "solidus_admin" %>
 </fieldset>
+
+<%= paginate @orders, theme: "solidus_admin" %>

--- a/backend/app/views/spree/admin/users/orders.html.erb
+++ b/backend/app/views/spree/admin/users/orders.html.erb
@@ -2,10 +2,104 @@
 <% admin_breadcrumb(link_to @user.email, edit_admin_user_url(@user)) %>
 <% admin_breadcrumb(t('spree.admin.user.order_history')) %>
 
-
 <%= render 'spree/admin/users/sidebar' %>
 <%= render 'spree/admin/users/tabs', current: :orders %>
 <%= render partial: 'spree/admin/users/user_page_actions' %>
+
+<% content_for :table_filter_title do %>
+  <%= t('spree.search') %>
+<% end %>
+
+<% content_for :table_filter do %>
+  <div data-hook="admin_user_orders_index_search">
+    <%= search_form_for [:admin, @search], url: orders_admin_user_path(@user.id) do |f| %>
+      <div class="row">
+        <div class="field-block col-12 col-md-6 col-lg-4 col-xl-3">
+          <div class="date-range-filter field">
+            <%= label_tag :q_created_at_gt, t('spree.date_range') %>
+
+            <div class="date-range-fields input-group">
+              <%= f.text_field :created_at_gt, class: "datepicker form-control datepicker-from",
+                value: params[:q][:created_at_gt],
+                placeholder: t("spree.start") %>
+
+              <div class="input-group-prepend input-group-append">
+                <span class="input-group-text range-divider">
+                  <i class="fa fa-arrow-right"></i>
+                </span>
+              </div>
+
+              <%= f.text_field :created_at_lt, class: "datepicker form-control datepicker-to",
+                value: params[:q][:created_at_lt],
+                placeholder: t("spree.end") %>
+            </div>
+          </div>
+
+          <div class="field">
+            <%= label_tag :q_state_eq, t("spree.status") %>
+            <%= f.select :state_eq, Spree::Order.state_machines[:state].states.collect {
+              |s| [t(s.name, scope: "spree.order_state"), s.value]
+            }, { include_blank: true }, class: "custom-select fullwidth" %>
+          </div>
+        </div>
+
+        <div class="col-12 col-md-6 col-lg-4 col-xl-6">
+          <div class="row">
+            <div class="col-12 col-xl-6">
+              <div class="field">
+                <%= label_tag :q_number_start, t("spree.order_number", number: "") %>
+                <%= f.text_field :number_start %>
+              </div>
+
+              <div class="field">
+                <%= label_tag :q_email_start, t("spree.email") %>
+                <%= f.text_field :email_start %>
+              </div>
+            </div>
+
+            <div class="col-12 col-xl-6">
+              <div class="field">
+                <%= label_tag :q_bill_address_firstname_start, t("spree.first_name_begins_with") %>
+                <%= f.text_field :bill_address_firstname_start, size: 25 %>
+              </div>
+
+              <div class="field">
+                <%= label_tag :q_bill_address_lastname_start, t("spree.last_name_begins_with") %>
+                <%= f.text_field :bill_address_lastname_start, size: 25 %>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-12 col-md-6 col-lg-4 col-xl-3">
+          <% if Spree::Store.count > 1 %>
+            <div class="field">
+              <%= label_tag :q_store_id_eq, t("spree.store") %>
+              <%= f.select :store_id_eq, Spree::Store.find_each.map {
+                |s| [s.name, s.id]
+              }, { include_blank: true }, { class: "custom-select fullwidth" } %>
+            </div>
+          <% end %>
+
+          <div class="field checkbox">
+            <label>
+              <%= f.check_box :completed_at_not_null, { checked: @only_completed_orders }, "1", "0" %>
+              <%= t("spree.show_only_complete_orders") %>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div class="clearfix"></div>
+
+      <div class="actions filter-actions">
+        <div data-hook="admin_user_orders_index_search_buttons">
+          <%= button_tag t("spree.filter_results"), class: "btn btn-primary" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>
 
 <fieldset data-hook="admin_user_order_history" class="no-border-bottom">
   <legend><%= t("spree.admin.user.order_history") %></legend>
@@ -13,7 +107,6 @@
   <%= paginate @orders, theme: "solidus_admin" %>
 
   <% if @orders.any? %>
-    <%# TODO add search interface %>
     <table class="index" id="listing_orders" data-hook>
       <colgroup>
          <col style="width: 25%;">

--- a/backend/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users_controller_spec.rb
@@ -225,7 +225,7 @@ describe Spree::Admin::UsersController, type: :controller do
       can :manage, Spree.user_class
     end
 
-    let(:order) { create(:order) }
+    let(:order) { create(:completed_order_with_totals) }
     before { user.orders << order }
 
     it "assigns a list of the users orders" do

--- a/backend/spec/features/admin/users_spec.rb
+++ b/backend/spec/features/admin/users_spec.rb
@@ -354,6 +354,95 @@ describe 'Users', type: :feature do
     end
   end
 
+  context 'searching orders', js: true do
+    before do
+      allow_any_instance_of(Spree::OrderInventory).to receive(:add_to_shipment)
+      visit spree.orders_admin_user_path(user_b)
+    end
+
+    let!(:old_order) { create(:completed_order_with_totals, user: user_b) }
+    let!(:new_order) { create(:completed_order_with_totals, user: user_b) }
+
+    context 'by dates' do
+      before do
+        old_order.created_at = 1.year.ago
+        old_order.completed_at = 1.year.ago
+        old_order.save!
+      end
+
+      it 'filters orders based in the selected date range' do
+        fill_in 'q_created_at_gt', with: 1.week.ago
+        # No need to fill out the `q_created_at_lt` field
+        # as it automatically defaults to the current date
+        #
+        # Take into consideration that, given that JS elements
+        # do not dismiss automatically under test environments,
+        # it is complicated to fill out said field without blocking
+        # the "Filter Results" button or without relying on manually
+        # handling the DOM, something which is not recommended since
+        # it may cause fragile and/or flaky specs
+        click_button 'Filter Results'
+
+        within_table 'listing_orders' do
+          expect(page).to have_content(new_order.number)
+          expect(page).not_to have_content(old_order.number)
+        end
+      end
+    end
+
+    context 'by status' do
+      let!(:not_completed) { create(:order_ready_to_complete, user: user_b) }
+
+      it 'filters orders based on their status' do
+        uncheck 'q_completed_at_not_null'
+        select 'Confirm', from: 'q_state_eq'
+        click_button 'Filter Results'
+
+        within_table 'listing_orders' do
+          expect(page).to have_content(not_completed.number)
+          expect(page).not_to have_content(old_order.number)
+          expect(page).not_to have_content(new_order.number)
+        end
+      end
+    end
+
+    context 'by order number' do
+      it 'filters orders based on their order number' do
+        fill_in 'q_number_start', with: new_order.number
+        click_button 'Filter Results'
+
+        within_table 'listing_orders' do
+          expect(page).to have_content(new_order.number)
+          expect(page).not_to have_content(old_order.number)
+        end
+      end
+    end
+
+    context 'by store' do
+      let!(:us_store) { create(:store, name: 'US Store') }
+      let!(:eu_store) { create(:store, name: 'EU Store') }
+
+      before do
+        new_order.update_attributes!(number: "R-#{us_store.id}-6320", store: us_store)
+        old_order.update_attributes!(number: "R-#{eu_store.id}-3477", store: eu_store)
+
+        # For some reason, the dropdown list for stores is not available when the page
+        # first load, hence a reload is necessary in here
+        visit current_path
+      end
+
+      it 'filters orders based on the store they were created' do
+        select eu_store.name, from: 'q_store_id_eq'
+        click_button 'Filter Results'
+
+        within_table 'listing_orders' do
+          expect(page).to have_content(old_order.number)
+          expect(page).not_to have_content(new_order.number)
+        end
+      end
+    end
+  end
+
   context 'items purchased with sorting' do
     before do
       orders


### PR DESCRIPTION
**Description**

This PR adds a search interface for orders under `admin/users/:id/orders`; it was a pending `TODO` as per [this comment](https://github.com/solidusio/solidus/blob/master/backend/app/views/spree/admin/users/orders.html.erb#L16).

It emulates, til some point, the functionality under `admin/orders`. While it takes most of the fields used on that view, it does not consider others, as the modified view is limited in space and I think it's for the best to keep it as clean and concise as possible.

I also think, given the context, that admins might be not be interested in such specific details under a particular user.

Given the similarities between this view/controller action and the one for `admin/orders`, I think there might be room for a refactor, to DRY things up a little bit, but that'd be included on another PR if this one gets approved for Solidus.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
