### PR TITLE
[Internal RFC] Create RSpec helpers for migrations specs

### DIFF
--- a/core/spec/migrate/20191001071110_convert_calculator_type_to_promotion_calculators_spec.rb
+++ b/core/spec/migrate/20191001071110_convert_calculator_type_to_promotion_calculators_spec.rb
@@ -3,57 +3,10 @@
 require 'rails_helper'
 require Spree::Core::Engine.root.join('db/migrate/20191001071110_convert_calculator_type_to_promotion_calculators.rb')
 
-RSpec.describe ConvertCalculatorTypeToPromotionCalculators do
-  let(:migrations_paths) { ActiveRecord::Migrator.migrations_paths }
-  let(:migrations) do
-    if Rails.gem_version >= Gem::Version.new('6.0.0')
-      ActiveRecord::MigrationContext.new(
-        migrations_paths,
-        ActiveRecord::SchemaMigration
-      ).migrations
-    elsif Rails.gem_version >= Gem::Version.new('5.2.0')
-      ActiveRecord::MigrationContext.new(migrations_paths).migrations
-    else
-      ActiveRecord::Migrator.migrations(migrations_paths)
-    end
-  end
-  let(:previous_version) { 20190220093635 }
-  let(:current_version) { 20191001071110 }
-
-  subject do
-    if Rails.gem_version >= Gem::Version.new('6.0.0')
-      ActiveRecord::Migrator.new(:up, migrations, ActiveRecord::SchemaMigration, current_version).migrate
-    else
-      ActiveRecord::Migrator.new(:up, migrations, current_version).migrate
-    end
-  end
-
-  # This is needed for MySQL since it is not able to rollback to the previous
-  # state when database schema changes within that transaction.
-  before(:all) { self.use_transactional_tests = false }
-  after(:all)  { self.use_transactional_tests = true }
-
-  around do |example|
-    DatabaseCleaner.clean_with(:truncation)
-    # Silence migrations output in specs report.
-    ActiveRecord::Migration.suppress_messages do
-      # Migrate back to the previous version
-      if Rails.gem_version >= Gem::Version.new('6.0.0')
-        ActiveRecord::Migrator.new(:down, migrations, ActiveRecord::SchemaMigration, previous_version).migrate
-      else
-        ActiveRecord::Migrator.new(:down, migrations, previous_version).migrate
-      end
-
-      example.run
-
-      if Rails.gem_version >= Gem::Version.new('6.0.0')
-        ActiveRecord::Migrator.new(:up, migrations, ActiveRecord::SchemaMigration).migrate
-      else
-        ActiveRecord::Migrator.new(:up, migrations).migrate
-      end
-    end
-    DatabaseCleaner.clean_with(:truncation)
-  end
+RSpec.describe ConvertCalculatorTypeToPromotionCalculators, type: :migration,
+                                                            described: 20191001071110,
+                                                            previous: 20190220093635 do
+  subject { |example| described_migration(example) }
 
   # This promotion factory creates a promotion action with
   # the flat rate calculator.

--- a/core/spec/support/migrations.rb
+++ b/core/spec/support/migrations.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative 'migrations/migrator_helper'
+
+RSpec.configure do |config|
+  config.include Migrations::MigratorHelpers, type: :migration
+
+  # This is needed for MySQL since it is not able to rollback to the previous
+  # state when database schema changes within that transaction.
+  config.before(:all, type: :migration) { self.use_transactional_tests = false }
+  config.after(:all, type: :migration)  { self.use_transactional_tests = true }
+
+  config.around(:each, type: :migration) do |example|
+    # Silence migrations output in specs report.
+    ActiveRecord::Migration.suppress_messages do
+      migrate_to_previous_migration_for(example)
+      clear_tables_cache(example)
+
+      example.run
+
+      DatabaseCleaner.clean_with(:truncation)
+      clear_tables_cache(example)
+      migrate_to_last_migration
+    end
+  end
+end

--- a/core/spec/support/migrations/migrator_helper.rb
+++ b/core/spec/support/migrations/migrator_helper.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Migrations
+  module MigratorHelpers
+    def migrate_to_described_migration_for(example)
+      migrate(example.metadata[:described])
+    end
+    alias :described_migration :migrate_to_described_migration_for
+
+    def migrate_to_previous_migration_for(example)
+      migrate(example.metadata[:previous], :down)
+    end
+
+    def migrate(version = nil, direction = :up)
+      if Rails.gem_version >= Gem::Version.new('6.0.0')
+        ActiveRecord::Migrator.new(direction, migrations, ActiveRecord::SchemaMigration, version).migrate
+      else
+        ActiveRecord::Migrator.new(direction, migrations, version).migrate
+      end
+    end
+
+    def migrate_to_last_migration
+      migrate
+    end
+
+    def migrations_paths
+      ActiveRecord::Migrator.migrations_paths
+    end
+
+    def migrations
+      if Rails.gem_version >= Gem::Version.new('6.0.0')
+        ActiveRecord::MigrationContext.new(
+          migrations_paths,
+          ActiveRecord::SchemaMigration
+        ).migrations
+      elsif Rails.gem_version >= Gem::Version.new('5.2.0')
+        ActiveRecord::MigrationContext.new(migrations_paths).migrations
+      else
+        ActiveRecord::Migrator.migrations(migrations_paths)
+      end
+    end
+
+    def clear_tables_cache(example)
+      (example.metadata[:reset_tables] || []).each(&:reset_column_information)
+    end
+  end
+end


### PR DESCRIPTION
**Description**

It will be easier to create new migration tests without too much boilerplate code.

Now that we have a couple of migration specs it's easier to spot what should be extracted into those helpers methods.

I'm hesitant to submit this PR into Solidus for several reasons:

- I'd like to understand if we can find the previous migration programmatically without the need to set it manually
- I don't like the `clear_tables_cache` method. I'd probably prefer to flush all the ActiveRecord tables cache rather than specifying which one we need to reset.

**Checklist:**
- [ ] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [ ] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [ ] I have added tests to cover this change (if needed)
