### PR TITLE
POC for services arquitecture

### DIFF
--- a/backend/app/controllers/spree/admin/stores_controller.rb
+++ b/backend/app/controllers/spree/admin/stores_controller.rb
@@ -3,6 +3,8 @@
 module Spree
   module Admin
     class StoresController < Spree::Admin::ResourceController
+      before_action :cast_currencies, only: %i[create update]
+
       def index
         if Spree::Store.count == 1
           redirect_to edit_admin_store_path(Spree::Store.first)
@@ -19,6 +21,10 @@ module Spree
 
       def permitted_params
         Spree::PermittedAttributes.store_attributes
+      end
+
+      def cast_currencies
+        params['store']['currencies'] = params['store']['currencies']&.to_set || Set[]
       end
     end
   end

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -53,10 +53,19 @@
     <%= f.field_container :default_currency do %>
       <%= f.label :default_currency %>
       <%= f.select :default_currency,
-        Spree::Config.available_currencies.map(&:iso_code),
+        available_currencies,
         { include_blank: true },
         { class: 'custom-select fullwidth' } %>
       <%= f.error_message_on :default_currency %>
+    <% end %>
+
+    <%= f.field_container :currencies do %>
+      <%= f.label :currencies %>
+      <%= f.select :currencies,
+        available_currencies,
+        { include_hidden: false },
+        { class: 'select2 fullwidth', multiple: true } %>
+      <%= f.error_message_on :currencies %>
     <% end %>
 
     <%= f.field_container :cart_tax_country_iso do %>

--- a/backend/spec/features/admin/stores_spec.rb
+++ b/backend/spec/features/admin/stores_spec.rb
@@ -8,7 +8,7 @@ describe 'Stores', type: :feature do
   context 'when adding a store' do
     before { visit spree.new_admin_store_path }
 
-    it 'admin should be able to set the default_currency' do
+    it 'admin should be able to configure currencies' do
       expect(find('#store_default_currency').value).to eq ''
 
       fill_in 'store_name', with: 'Solidus Store'
@@ -16,22 +16,47 @@ describe 'Stores', type: :feature do
       fill_in 'store_url', with: 'example.solidus.io'
       fill_in 'store_mail_from_address', with: 'from@solidus.io'
       select 'EUR', from: 'store_default_currency'
+      select 'USD', from: 'store_currencies'
+      select 'XOF', from: 'store_currencies'
       click_button 'Create'
 
-      @store = Spree::Store.last
+      store = Spree::Store.last
 
-      expect(@store.default_currency).to eq 'EUR'
+      expect(store.default_currency).to eq 'EUR'
+      expect(store.currencies).to eq Set['USD', 'XOF']
+    end
+
+    it 'admin should be able to create a store without currencies' do
+      fill_in 'store_name', with: 'Solidus Store'
+      fill_in 'store_code', with: 'solidus'
+      fill_in 'store_url', with: 'example.solidus.io'
+      fill_in 'store_mail_from_address', with: 'from@solidus.io'
+      click_button 'Create'
+
+      store = Spree::Store.last
+
+      expect(store.reload.currencies).to eq Set[]
     end
   end
 
   context 'when editing a store' do
-    let(:store) { create :store, default_currency: 'AUD' }
+    let(:store) { create :store, default_currency: 'AUD', currencies: Set['USD', 'EUR'] }
     before { visit spree.edit_admin_store_path(store) }
 
-    it 'admin should be able to change the default_currency' do
+    it 'admin should be able to change currencies' do
       select 'EUR', from: 'store_default_currency'
+      unselect 'EUR', from: 'store_currencies'
+      select 'XOF', from: 'store_currencies'
       click_button 'Update'
       expect(store.reload.default_currency).to eq 'EUR'
+      expect(store.reload.currencies).to eq Set['USD', 'XOF']
+    end
+
+    it 'admin should be able to remove all currencies' do
+      unselect 'EUR', from: 'store_currencies'
+      unselect 'USD', from: 'store_currencies'
+      click_button 'Update'
+      expect(store.reload.currencies).to eq Set[]
     end
   end
 end

--- a/core/app/lib/spree/types.rb
+++ b/core/app/lib/spree/types.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'dry/types'
+
+module Spree
+  # Types used in Solidus codebase
+  #
+  # This module includes all built-in types defined in
+  # [dry-types](https://dry-rb.org/gems/dry-types/) library, plus allows us to
+  # define and reuse our own types.
+  module Types
+    include Dry.Types()
+  end
+end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -721,6 +721,15 @@ module Spree
       end
     end
 
+    # Returns whether have been added some {#line_items}
+    #
+    # It considers both persisted and in-memory line items.
+    #
+    # @return [Boolean]
+    def items?
+      line_items.any?
+    end
+
     private
 
     def process_payments_before_complete

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -9,6 +9,8 @@ module Spree
   # hosted by a single Solidus implementation can be built.
   #
   class Store < Spree::Base
+    serialize :currencies, Set
+
     has_many :store_payment_methods, inverse_of: :store
     has_many :payment_methods, through: :store_payment_methods
 
@@ -41,6 +43,36 @@ module Spree
       else
         super(locales.map(&:to_s).join(","))
       end
+    end
+
+    # Currency in the absence of a user preference
+    #
+    # @return [String]
+    # @example
+    #   'USD'
+    def main_currency
+      default_currency.presence || Spree::Config.currency
+    end
+
+    # All currencies from which a user can choose
+    #
+    # These are {#main_currency} plus {#currencies}.
+    #
+    # @return [Set<String>]
+    # @see #currencies
+    # @see #main_currency
+    # @example
+    #   Set['BOB', 'EUR']
+    def supported_currencies
+      currencies + Set[main_currency]
+    end
+
+    # Whether the store has more than one supported currency
+    #
+    # @return [Boolean]
+    # @see #supported_currencies
+    def multicurrency?
+      supported_currencies.size > 1
     end
 
     def self.default

--- a/core/app/models/spree/variant/pricing_options.rb
+++ b/core/app/models/spree/variant/pricing_options.rb
@@ -49,13 +49,24 @@ module Spree
         new(currency: price.currency, country_iso: price.country_iso)
       end
 
-      # This creates the correct pricing options for a price, so the store owners can easily customize how to
-      # find the pricing based on the view context, having available current_store, current_spree_user, request.host_name, etc.
-      # @return [Spree::Variant::PricingOptions] pricing options for pricing a line item
+      # This creates the correct pricing options for a price, so the store
+      # owners can easily customize how to find the pricing based on the view
+      # context, having available current_store, current_spree_user,
+      # request.host_name, etc.
+      #
+      # Currency is fetched from the session when set, otherwise it falls back
+      # to {Store#main_currency}. The country iso is copied from
+      # {Store#cart_tax_cart_tax_country_iso}.
+      #
+      #
+      # @return [Spree::Variant::PricingOptions] pricing options for pricing a
+      # line item
       def self.from_context(context)
+        store = context.current_store
+
         new(
-          currency: context.current_store.try!(:default_currency).presence || Spree::Config[:currency],
-          country_iso: context.current_store.try!(:cart_tax_country_iso).presence
+          currency: context.currency_in_session || store.main_currency,
+          country_iso: store.cart_tax_country_iso
         )
       end
 

--- a/core/app/services/spree/result.rb
+++ b/core/app/services/spree/result.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'dry/struct'
+require 'spree/types'
+
+module Spree
+  # Simple struct that represents the value returned by a service
+  class Result < Dry::Struct
+    schema schema.strict
+
+    attribute? :result, Types::Any.optional
+    attribute? :failure, Types::Any.optional
+
+    # @return [Boolean]
+    def success?
+      failure.nil?
+    end
+
+    # @return [Boolean]
+    def failure?
+      result.nil?
+    end
+  end
+end

--- a/core/app/services/spree/switch_currency_service.rb
+++ b/core/app/services/spree/switch_currency_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Spree
+  # Manage current order when the currency is switched in the frontend
+  #
+  # It just empties the order, which translates into removing any line item
+  # added to the cart.
+  class SwitchCurrencyService
+    include Dry::Monads[:maybe, :result]
+
+    # @return [Spree::Result]
+    def call(order)
+      Some(
+        order.empty!
+      ).to_spree_result
+    end
+  end
+end

--- a/core/config/initializers/dry_monads.rb
+++ b/core/config/initializers/dry_monads.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'dry/core/extensions'
+require 'dry/monads'
+
+# This initializer defines an extension for Dry::Monads to transform result
+# related dry-monads's objects into a Spree::Result
+
+module Dry
+  module Monads
+    extend Dry::Core::Extensions
+
+    register_extension(:spree_result) do
+      class Result
+        class Success < Result
+          # @return [Spree::Result]
+          def to_spree_result
+            Spree::Result.new(result: value!)
+          end
+        end
+
+        class Failure < Result
+          # @return [Spree::Result]
+          def to_spree_result
+            Spree::Result.new(failure: failure)
+          end
+        end
+      end
+
+      class Maybe
+        # @return [Spree::Result]
+        def to_spree_result
+          to_result
+            .to_spree_result
+        end
+      end
+
+      class Try
+        # @return [Spree::Result]
+        def to_spree_result
+          to_result
+            .to_spree_result
+        end
+      end
+    end
+  end
+end
+
+Dry::Monads.load_extensions(:spree_result)

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1205,6 +1205,7 @@ en:
     credit_owed: Credit Owed
     credits: Credits
     currency: Currency
+    currency_switch_confirm: If you switch currency your cart will be emptied. Are you sure you want to continue?
     currency_settings: Currency Settings
     current: Current
     current_promotion_usage: 'Current Usage: %{count}'

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -1206,6 +1206,7 @@ en:
     credits: Credits
     currency: Currency
     currency_switch_confirm: If you switch currency your cart will be emptied. Are you sure you want to continue?
+    currency_switch_error: There was an error switching the currency
     currency_settings: Currency Settings
     current: Current
     current_promotion_usage: 'Current Usage: %{count}'

--- a/core/db/migrate/20210323153802_add_currencies_to_stores.rb
+++ b/core/db/migrate/20210323153802_add_currencies_to_stores.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCurrenciesToStores < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spree_stores, :currencies, :text
+  end
+end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -455,6 +455,14 @@ module Spree
     # Enumerable of taxons adhering to the present_taxon_class interface
     class_name_attribute :taxon_attachment_module, default: 'Spree::Taxon::ActiveStorageAttachment'
 
+    # Service to manage order when switching currency
+    #
+    # `Spree::SwitchCurrencyService` is the default.
+    #
+    # @!attribute [rw] switch_currency_service_class
+    # @return [Class]
+    class_name_attribute :switch_currency_service_class, default: 'Spree::SwitchCurrencyService'
+
     # Allows providing your own class instance for generating order numbers.
     #
     # @!attribute [rw] order_number_generator

--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -10,7 +10,8 @@ module Spree
         include ControllerHelpers::Pricing
 
         included do
-          helper_method :current_order
+          helper_method :current_order,
+                        :current_order_in_progress?
         end
 
         # The current incomplete order from the guest_token for use in cart and during checkout
@@ -34,6 +35,13 @@ module Spree
             @current_order.record_ip_address(ip_address)
             return @current_order
           end
+        end
+
+        # Whether some items have been added to the current order
+        #
+        # @return [Boolean]
+        def current_order_in_progress?
+          current_order.present? && current_order.items?
         end
 
         def associate_user

--- a/core/lib/spree/core/controller_helpers/pricing.rb
+++ b/core/lib/spree/core/controller_helpers/pricing.rb
@@ -7,11 +7,45 @@ module Spree
         extend ActiveSupport::Concern
 
         included do
-          helper_method :current_pricing_options
+          # Key where the current currency should be stored in a requests' session
+          CURRENCY_SESSION_KEY = 'currency'
+
+          helper_method :current_pricing_options,
+                        :current_currency,
+                        :switch_currency
         end
 
+        # @see Variant::PricingOptions#from_context
         def current_pricing_options
           Spree::Config.pricing_options_class.from_context(self)
+        end
+
+        # Current currency from {#current_pricing_options}
+        #
+        # @return [String]
+        # @see #current_pricing_options
+        # @example
+        #   'USD'
+        def current_currency
+          current_pricing_options.currency
+        end
+
+        # Currency stored in the session
+        #
+        # @return [String, nil]
+        # @see CURRENCY_SESSION_KEY
+        # @example
+        #   'USD'
+        def currency_in_session
+          session[CURRENCY_SESSION_KEY]
+        end
+
+        # Stores given currency in the session
+        #
+        # @param currency [String]
+        # @see #currency_in_session
+        def switch_currency(currency)
+          session[CURRENCY_SESSION_KEY] = currency
         end
       end
     end

--- a/core/lib/spree/core/controller_helpers/store.rb
+++ b/core/lib/spree/core/controller_helpers/store.rb
@@ -7,11 +7,25 @@ module Spree
         extend ActiveSupport::Concern
 
         included do
-          helper_method :current_store
+          helper_method :current_store,
+                        :available_currencies,
+                        :supported_currencies,
+                        :multicurrency?
+          delegate :supported_currencies,
+                   :multicurrency?, to: :current_store
         end
 
         def current_store
           @current_store ||= Spree::Config.current_store_selector_class.new(request).store
+        end
+
+        # Array of iso codes for all available currencies
+        #
+        # @return [Array<String>]
+        # @example
+        #   ['USD', 'EUR']
+        def available_currencies
+          Spree::Config.available_currencies.map(&:iso_code)
         end
       end
     end

--- a/core/lib/spree/testing_support/factories/store_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_factory.rb
@@ -11,5 +11,6 @@ FactoryBot.define do
     sequence(:name) { |i| "Spree Test Store #{i}" }
     sequence(:url) { |i| "www.example#{i}.com" }
     mail_from_address { 'solidus@example.org' }
+    currencies { Set[] }
   end
 end

--- a/core/solidus_core.gemspec
+++ b/core/solidus_core.gemspec
@@ -42,6 +42,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'kt-paperclip', '~> 6.3'
   s.add_dependency 'ransack', '~> 2.0'
   s.add_dependency 'state_machines-activerecord', '~> 0.6'
+  s.add_dependency 'dry-core', '~> 0.5'
+  s.add_dependency 'dry-struct', '~> 1.4'
+  s.add_dependency 'dry-monads', '~> 1.3'
 
   s.post_install_message = <<-MSG
 -------------------------------------------------------------

--- a/core/spec/lib/spree/core/controller_helpers/order_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/order_spec.rb
@@ -116,4 +116,18 @@ RSpec.describe Spree::Core::ControllerHelpers::Order, type: :controller do
       expect(controller.ip_address).to eq request.remote_ip
     end
   end
+
+  describe '#current_order_in_progress?' do
+    it 'returns whether current order contains items' do
+      create(:order, store: store, user: user, line_items: [build(:line_item)])
+
+      expect(controller.current_order_in_progress?).to be(true)
+    end
+
+    context 'when there is no current order' do
+      it 'returns false' do
+        expect(controller.current_order_in_progress?).to be(false)
+      end
+    end
+  end
 end

--- a/core/spec/lib/spree/core/controller_helpers/pricing_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/pricing_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Spree::Core::ControllerHelpers::Pricing, type: :controller do
     include Spree::Core::ControllerHelpers::Pricing
   }
 
-  before do
-    allow(controller).to receive(:current_store).and_return(store)
-  end
-
   describe '#current_pricing_options' do
+    before do
+      allow(controller).to receive(:current_store).and_return(store)
+    end
+
     subject { controller.current_pricing_options }
 
     let(:store) { FactoryBot.create(:store, default_currency: nil) }
@@ -22,21 +22,9 @@ RSpec.describe Spree::Core::ControllerHelpers::Pricing, type: :controller do
     context "currency" do
       subject { controller.current_pricing_options.currency }
 
-      context "when store default_currency is nil" do
-        let(:store) { nil }
+      context "returns store currency from the context" do
+        let(:store) { create(:store, default_currency: 'USD') }
         it { is_expected.to eq('USD') }
-      end
-
-      context "when the current store default_currency empty" do
-        let(:store) { FactoryBot.create :store, default_currency: '' }
-
-        it { is_expected.to eq('USD') }
-      end
-
-      context "when the current store default_currency is a currency" do
-        let(:store) { FactoryBot.create :store, default_currency: 'EUR' }
-
-        it { is_expected.to eq('EUR') }
       end
     end
 
@@ -67,6 +55,22 @@ RSpec.describe Spree::Core::ControllerHelpers::Pricing, type: :controller do
           is_expected.to be_nil
         end
       end
+    end
+  end
+
+  describe '#currency_in_session' do
+    it 'returns currency value in the session' do
+      controller.session['currency'] = 'BOB'
+
+      expect(controller.currency_in_session).to eq('BOB')
+    end
+  end
+
+  describe '#switch_currency' do
+    it 'sets given currency to session' do
+      controller.switch_currency('BOB')
+
+      expect(controller.current_currency).to eq('BOB')
     end
   end
 end

--- a/core/spec/lib/spree/core/controller_helpers/store_spec.rb
+++ b/core/spec/lib/spree/core/controller_helpers/store_spec.rb
@@ -13,4 +13,26 @@ RSpec.describe Spree::Core::ControllerHelpers::Store, type: :controller do
       expect(controller.current_store).to eq store
     end
   end
+
+  describe '#available_currencies' do
+    it 'returns array of all currencies iso code' do
+      expect(controller.available_currencies).to include('USD')
+    end
+  end
+
+  describe '#supported_currencies' do
+    it 'returns set of all currencies supported by the current store' do
+      create :store, default: true, default_currency: 'USD', currencies: Set['EUR']
+
+      expect(controller.supported_currencies).to eq(Set['USD', 'EUR'])
+    end
+  end
+
+  describe '#multicurrency?' do
+    it 'returns whether current store is multicurrency' do
+      create :store, default: true, default_currency: 'USD', currencies: Set['EUR']
+
+      expect(controller.multicurrency?).to be(true)
+    end
+  end
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1655,4 +1655,22 @@ RSpec.describe Spree::Order, type: :model do
       expect(subject).to eq 40
     end
   end
+
+  describe '#items?' do
+    context 'when order has some line items' do
+      it 'returns true' do
+        order = build(:order, line_items: [build(:line_item)])
+
+        expect(order.items?).to be(true)
+      end
+    end
+
+    context 'when order has no line items' do
+      it 'returns false' do
+        order = build(:order, line_items: [])
+
+        expect(order.items?).to be(false)
+      end
+    end
+  end
 end

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -106,4 +106,56 @@ RSpec.describe Spree::Store, type: :model do
       end
     end
   end
+
+  describe '#main_currency' do
+    context 'when default_currency is set' do
+      it 'returns it' do
+        store = build(:store, default_currency: 'BOB')
+
+        expect(store.main_currency).to eq('BOB')
+      end
+    end
+
+    context 'when default_currency is not set' do
+      it 'returns the one from the configuration' do
+        store = build(:store, default_currency: nil)
+
+        expect(store.main_currency).to eq('USD')
+      end
+    end
+
+    context 'when default_currency is the empty string' do
+      it 'returns the one from the configuration' do
+        store = build(:store, default_currency: '')
+
+        expect(store.main_currency).to eq('USD')
+      end
+    end
+  end
+
+  context '#supported_currencies' do
+    it 'returns set with main currency and other supported currencies' do
+      store = build(:store, default_currency: 'USD', currencies: Set['EUR', 'BOB'])
+
+      expect(store.supported_currencies).to eq(Set['USD', 'EUR', 'BOB'])
+    end
+  end
+
+  context '#multicurrency?' do
+    context 'when there is more than one supported currency' do
+      it 'returns true' do
+        store = build(:store, default_currency: 'USD', currencies: Set['BOB'])
+
+        expect(store.multicurrency?).to be(true)
+      end
+    end
+
+    context 'when there is only one supported currency' do
+      it 'returns false' do
+        store = build(:store, default_currency: 'USD', currencies: Set[])
+
+        expect(store.multicurrency?).to be(false)
+      end
+    end
+  end
 end

--- a/frontend/app/assets/javascripts/spree/frontend.js
+++ b/frontend/app/assets/javascripts/spree/frontend.js
@@ -3,3 +3,4 @@
 //= require spree/frontend/product
 //= require spree/frontend/cart
 //= require spree/frontend/locale_selector
+//= require spree/frontend/currency_selector

--- a/frontend/app/assets/javascripts/spree/frontend/currency_selector.js
+++ b/frontend/app/assets/javascripts/spree/frontend/currency_selector.js
@@ -1,0 +1,16 @@
+$(function() {
+  $('#currency_selector select').change(function() {
+    var select = this;
+    var form = this.form;
+    Spree.ajax({
+      url: Spree.pathFor('/orders/current_order_has_items'),
+      success: function(data) {
+        if (data['result'] && !confirm($(form).data('confirm-text'))) {
+          $(select).val($(form).data('current-currency'));
+        } else {
+          form.submit();
+        }
+      }
+    });
+  });
+});

--- a/frontend/app/assets/javascripts/spree/frontend/currency_selector.js
+++ b/frontend/app/assets/javascripts/spree/frontend/currency_selector.js
@@ -2,15 +2,10 @@ $(function() {
   $('#currency_selector select').change(function() {
     var select = this;
     var form = this.form;
-    Spree.ajax({
-      url: Spree.pathFor('/orders/current_order_has_items'),
-      success: function(data) {
-        if (data['result'] && !confirm($(form).data('confirm-text'))) {
-          $(select).val($(form).data('current-currency'));
-        } else {
-          form.submit();
-        }
-      }
-    });
+    if ($(form).data('needs-confirm') && !confirm($(form).data('confirm-text'))) {
+      $(select).val($(form).data('current-currency'));
+    } else {
+      form.submit();
+    }
   });
 });

--- a/frontend/app/controllers/spree/currencies_controller.rb
+++ b/frontend/app/controllers/spree/currencies_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Spree
+  class CurrenciesController < Spree::StoreController
+    def set
+      switch_currency(params[:switch_to_currency])
+      current_order&.empty!
+
+      redirect_back(fallback_location: root_path)
+    end
+  end
+end

--- a/frontend/app/controllers/spree/currencies_controller.rb
+++ b/frontend/app/controllers/spree/currencies_controller.rb
@@ -4,9 +4,18 @@ module Spree
   class CurrenciesController < Spree::StoreController
     def set
       switch_currency(params[:switch_to_currency])
-      current_order&.empty!
+
+      if current_order && switch_currency_service.call(current_order).failure?
+        flash[:error] = t('spree.currency_switch_error')
+      end
 
       redirect_back(fallback_location: root_path)
+    end
+
+    private
+
+    def switch_currency_service
+      Spree::Config.switch_currency_service_class.new
     end
   end
 end

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -101,6 +101,10 @@ module Spree
       end
     end
 
+    def current_order_has_items
+      render json: { result: current_order_in_progress? }
+    end
+
     private
 
     def store_guest_token

--- a/frontend/app/controllers/spree/orders_controller.rb
+++ b/frontend/app/controllers/spree/orders_controller.rb
@@ -101,10 +101,6 @@ module Spree
       end
     end
 
-    def current_order_has_items
-      render json: { result: current_order_in_progress? }
-    end
-
     private
 
     def store_guest_token

--- a/frontend/app/views/spree/shared/_currency_selector.html.erb
+++ b/frontend/app/views/spree/shared/_currency_selector.html.erb
@@ -1,0 +1,19 @@
+<% if multicurrency? %>
+  <li id="currency_selector" data-hook>
+    <%= form_tag spree.select_currency_path, class: 'navbar-form', method: :put, data: { current_currency: current_currency, confirm_text: I18n.t('spree.currency_switch_confirm') } do %>
+      <div class="form-group">
+        <label for="switch_currency" class="sr-only">
+          <%= I18n.t('spree.currency') %>
+        </label>
+        <%= select_tag(
+            :switch_to_currency,
+            options_for_select(
+              supported_currencies,
+              selected: current_currency
+            ),
+            class: 'form-control') %>
+        <noscript><%= submit_tag t("spree.select") %></noscript>
+      </div>
+    <% end %>
+  </li>
+<% end %>

--- a/frontend/app/views/spree/shared/_currency_selector.html.erb
+++ b/frontend/app/views/spree/shared/_currency_selector.html.erb
@@ -1,6 +1,13 @@
 <% if multicurrency? %>
   <li id="currency_selector" data-hook>
-    <%= form_tag spree.select_currency_path, class: 'navbar-form', method: :put, data: { current_currency: current_currency, confirm_text: I18n.t('spree.currency_switch_confirm') } do %>
+    <%= form_tag spree.select_currency_path,
+      class: 'navbar-form',
+      method: :put,
+      data: {
+        current_currency: current_currency,
+        confirm_text: I18n.t('spree.currency_switch_confirm'),
+        needs_confirm: current_order_in_progress?
+      } do %>
       <div class="form-group">
         <label for="switch_currency" class="sr-only">
           <%= I18n.t('spree.currency') %>

--- a/frontend/app/views/spree/shared/_nav_bar.html.erb
+++ b/frontend/app/views/spree/shared/_nav_bar.html.erb
@@ -1,5 +1,6 @@
 <nav id="top-nav-bar" class="columns ten">
   <ul id="nav-bar" class="inline" data-hook>
+    <%= render 'spree/shared/currency_selector' %>
     <%= render 'spree/shared/locale_selector' %>
     <%= render 'spree/shared/login_bar_items' %>
     <li id="search-bar" data-hook>

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -17,7 +17,6 @@ Spree::Core::Engine.routes.draw do
 
   get '/orders/populate', to: 'orders#populate_redirect'
   get '/orders/:id/token/:token' => 'orders#show', as: :token_order
-  get '/orders/current_order_has_items' => 'orders#current_order_has_items', format: :json
 
   resources :orders, except: [:index, :new, :create, :destroy] do
     post :populate, on: :collection

--- a/frontend/config/routes.rb
+++ b/frontend/config/routes.rb
@@ -8,6 +8,8 @@ Spree::Core::Engine.routes.draw do
   get '/locale/set', to: 'locale#set'
   post '/locale/set', to: 'locale#set', as: :select_locale
 
+  put '/currencies/set', to: 'currencies#set', as: :select_currency
+
   # non-restful checkout stuff
   patch '/checkout/update/:state', to: 'checkout#update', as: :update_checkout
   get '/checkout/:state', to: 'checkout#edit', as: :checkout_state
@@ -15,6 +17,7 @@ Spree::Core::Engine.routes.draw do
 
   get '/orders/populate', to: 'orders#populate_redirect'
   get '/orders/:id/token/:token' => 'orders#show', as: :token_order
+  get '/orders/current_order_has_items' => 'orders#current_order_has_items', format: :json
 
   resources :orders, except: [:index, :new, :create, :destroy] do
     post :populate, on: :collection

--- a/frontend/spec/features/switch_currency_spec.rb
+++ b/frontend/spec/features/switch_currency_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'switch currency', type: :feature, js: true do
+  context 'with empty cart' do
+    it 'user can switch currency' do
+      create(:store, default_currency: 'USD', currencies: Set['EUR'])
+      product = create(:product, price: 20)
+      create(:price, variant: product.master, amount: 15, currency: 'EUR')
+
+      visit spree.root_path
+
+      expect(page).to have_content('$20')
+      expect(page).not_to have_content('€15')
+
+      select 'EUR', from: 'switch_to_currency'
+
+      expect(page).to have_content('€15')
+      expect(page).not_to have_content('$20')
+    end
+  end
+
+  context 'with products added to the cart' do
+    it 'user can empty cart and switch currency' do
+      create(:store, default_currency: 'USD', currencies: Set['EUR'])
+      product = create(:product, name: 'Product foo', price: 20)
+      create(:price, variant: product.master, amount: 15, currency: 'EUR')
+
+      visit spree.root_path
+
+      expect(page).to have_content('$20')
+      expect(page).not_to have_content('€15')
+
+      click_on 'Product foo'
+      click_on 'Add To Cart'
+      accept_confirm do
+        select 'EUR', from: 'switch_to_currency'
+      end
+
+      expect(page).not_to have_content('Checkout')
+
+      visit spree.root_path
+
+      expect(page).to have_content('€15')
+      expect(page).not_to have_content('$20')
+    end
+
+    it 'user can keep cart and dismiss switching currency' do
+      create(:store, default_currency: 'USD', currencies: Set['EUR'])
+      product = create(:product, name: 'Product foo', price: 20)
+      create(:price, variant: product.master, amount: 15, currency: 'EUR')
+
+      visit spree.root_path
+
+      expect(page).to have_content('$20')
+      expect(page).not_to have_content('€15')
+
+      click_on 'Product foo'
+      click_on 'Add To Cart'
+      dismiss_confirm do
+        select 'EUR', from: 'switch_to_currency'
+      end
+
+      expect(page).to have_content('Checkout')
+
+      visit spree.root_path
+
+      expect(page).to have_content('$20')
+      expect(page).not_to have_content('€15')
+    end
+  end
+end


### PR DESCRIPTION
This is a POC to show a proposal for the introduction of a service layer
on solidus-core. As it's just a draft, it's not a finished work and
tests and better docs are missing.

As we talked with @kennyadsl, it'd good to be able to use dry-rb tools
as they can help a lot in the introduction of more advanced patterns.
However, the fear existed that it could leave some people out because
the differences with the standard Rails way. This proposal tries to
reach a compromise by introducing a separation between what we can use
internally and what a solidus user needs to know in order to extend its
application. I.e. it uses some libraries internally but it doesn't
require them to extend the framework.

The intersection point between both scenarios is the `Spree::Result`
struct. The idea is that every service on solidus-core must return an
instance of it. Services need to be configurable, so we're going to
provide a default implementation, but users can switch it by their own
one.

The default implementation should be build using
[dry-monads](https://dry-rb.org/gems/dry-monads/). This POC already
applies it to the service to switch a currency. It's not the best
example as it's very simple, but you can get an idea about how powerful
is the library for the kind of logic required for
services/operations/business-transactions reading at its website
(`Maybe`, `Result` & `Try`).

The result of building the service with dry-monads is transformed to a
`Spree::Result` through a `#to_spree_result` method that has been added
as an extension. For that we're using a [dry-core
extension](https://dry-rb.org/gems/dry-core/0.4/extensions/) to show how
it works and makes it a little bit cleaner, but it really wouldn't make
any functional difference to use regular monkey patching instead.

If a user wants to implement its service, they can do as we do and use
dry-monads, or overpass it and do whatever they want as long as they end
up wrapping the result or failure in a `Spree::Result` object:

```ruby
Spree::Result.new(result: SomeResult)
Spree::Result.new(failure: SomeFailure)
```

Using this boundary object between the service layer and its consumer
(the controller) is, in fact, a good thing besides our intention here. Not
exposing all the power of dry-monads to the controller makes sure that
the heavy logic is implemented in the service while the controller only
has access to what is strictly necessary.

`Spree::Result` is internally a
[dry-struct](https://dry-rb.org/gems/dry-core/0.4/extensions/) struct.
It could also be implemented with Ruby's standard library `Struct` or
`OpenStruct` classes, but it has some benefits and avoids some of the
oddities that those default implementations have:

```ruby
Spree::Result.new(result: 'a') == Spree::Result.new(result: 'a') # => true
Struct.new(:result).new(result: 'a') == Struct.new(:result).new(result: 'a') # => false
OpenStruct.new(result: 'a') == OpenStruct.new(result: 'a') # => true

Spree::Result.new(result: 'a').other_method # => NoMethodError
Struct.new(:result).new(result: 'a').other_method # => NoMethodError
OpenStruct.new(result: 'a').other_method # => nil

Spree::Result.new(other_attribute: 'a') # => Dry::Struct::Error
Struct.new(:result).new(:other_attribute) # => #<struct result=:other_attribute>

Spree::Result.new(result: 'a') in {result: the_result} # Pattern matching...
the_result # => 'a'
Struct.new(:result).new(result: 'a') in {result: the_result}
the_result # => 'a'
OpenStruct.new(result: 'a') in {result: the_result} # NoMatchingPatternError
```

dry-struct carries with it
[dry-types](https://dry-rb.org/gems/dry-types/) dependency. As a future
work we could use it to refactor the current type-based configurations,
or even use
[dry-configurable](https://dry-rb.org/gems/dry-configurable/).

In case we accept something like this, a subsequent POC could try to
implement a neater way to inject configurable services.