### PR TITLE
Add debugging metadata to event objects

### DIFF
--- a/core/lib/spree/event.rb
+++ b/core/lib/spree/event.rb
@@ -56,6 +56,8 @@ module Spree
     # instead.
     # @option opts [Any] :adapter Reserved to indicate the adapter to use as
     # event bus. Defaults to {#default_adapter}
+    # @return [Spree::Event::Event] an event object, unless the adapter is
+    # {Spree::Event::Adapters::ActiveSupportNotifications}
     #
     # @example Trigger an event named 'order_finalized'
     #   Spree::Event.fire 'order_finalized', order: @order do

--- a/core/lib/spree/event/adapters/event_bus.rb
+++ b/core/lib/spree/event/adapters/event_bus.rb
@@ -34,9 +34,10 @@ module Spree
 
         # @api private
         def fire(event_name, opts = {})
-          event = Event.new(payload: opts)
-          listeners_for_event(event_name).each do |listener|
-            listener.call(event)
+          Event.new(payload: opts).tap do |event|
+            listeners_for_event(event_name).each do |listener|
+              listener.call(event)
+            end
           end
         end
 

--- a/core/lib/spree/event/event.rb
+++ b/core/lib/spree/event/event.rb
@@ -18,9 +18,29 @@ module Spree
       # @return [Hash]
       attr_reader :payload
 
+      # Creation time for the {Event} instance
+      #
+      # @return [Time]
+      attr_reader :time
+
+      # Relevant stack location for the creation of the {Event}
+      #
+      # It's set on initialization. It defaults to 4 levels up the stack to
+      # go through:
+      #
+      #   - The {#initialize} method.
+      #   - The adapter `#fire` method (for instance
+      #   {Spree::Events::Adapters#fire}).
+      #   - {Spree::Event.fire}.
+      #
+      # @return [Thread::Backtrace::Location]
+      attr_reader :caller_location
+
       # @api private
-      def initialize(payload:)
+      def initialize(payload: {}.freeze, caller_location: caller_locations(4, 1)[0])
         @payload = payload
+        @time = Time.now
+        @caller_location = caller_location
       end
     end
   end

--- a/core/spec/lib/spree/event/event_spec.rb
+++ b/core/spec/lib/spree/event/event_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Spree::Event::Event do
     it "sets its time attribute" do
       event = described_class.new
 
-      expect(event.time).not_to be_nil
+      expect(event.time).to be_a(Time)
     end
 
     it "sets its caller_location from given argument" do

--- a/core/spec/lib/spree/event/event_spec.rb
+++ b/core/spec/lib/spree/event/event_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spree/event/event'
+
+RSpec.describe Spree::Event::Event do
+  describe '#initialize' do
+    it "sets its time attribute" do
+      event = described_class.new
+
+      expect(event.time).not_to be_nil
+    end
+
+    it "sets its caller_location from given argument" do
+      event = described_class.new(caller_location: caller_locations(0, 1)[0])
+
+      expect(event.caller_location.to_s).to include(__FILE__)
+    end
+  end
+end

--- a/core/spec/lib/spree/event_spec.rb
+++ b/core/spec/lib/spree/event_spec.rb
@@ -58,6 +58,14 @@ RSpec.describe Spree::Event do
       expect(dummy.run).to be(true)
     end
 
+    it "passes its caller location as the event's caller location" do
+      bus = build_bus
+
+      event = subject.fire :foo, adapter: bus
+
+      expect(event.caller_location.to_s).to include(__FILE__)
+    end
+
     it 'raises error if a block is given and the adapter is not ActiveSupportNotifications' do
       expect do
         subject.fire :foo, adapter: build_bus do


### PR DESCRIPTION
We add two attributes to the instances of `Spree::Event::Event` to make
debugging and logging more accessible and useful:

- `time`: Contains the event creation time.
- `caller_location`: Contains an instance of
  `Thread::Backtrace::Location` pointing to the caller of
  `Spree::Event.fire`.

Probably, it'd be a better design to have `Spree::Event.fire` to
provide its caller location instead of defaulting to 4 levels up the
stack on `Spree::Event::Event`. However, as we're still dealing with the
legacy adapter, and it doesn't use `Spree::Event::Event` objects, for
now, it's better to leave things more straightforward to understand.

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
