### PR TITLE
Add test helper to allow injecting listeners into the event bus

### DIFF
--- a/core/lib/spree/event/adapters/default.rb
+++ b/core/lib/spree/event/adapters/default.rb
@@ -61,6 +61,20 @@ module Spree
           self.class.new(listeners)
         end
 
+        # @api private
+        def with_injected_listeners(injections)
+          to_replace = injections.keys
+          mapping, new_listeners = listeners.reduce([{}, []]) do |(mapping, new_listeners), listener|
+            if to_replace.include?(listener)
+              new_listener = listener.with_block(injections[listener])
+              [mapping.merge(listener => new_listener), new_listeners << new_listener]
+            else
+              [mapping, new_listeners + [listener]]
+            end
+          end
+          [self.class.new(new_listeners), mapping]
+        end
+
         private
 
         def listeners_for_event(event_name)

--- a/core/lib/spree/event/adapters/default.rb
+++ b/core/lib/spree/event/adapters/default.rb
@@ -27,8 +27,8 @@ module Spree
         # @api private
         attr_reader :listeners
 
-        def initialize
-          @listeners = []
+        def initialize(listeners = [])
+          @listeners = listeners
         end
 
         # @api private
@@ -54,6 +54,11 @@ module Spree
           else
             unsubscribe_event(subscriber_or_event_name)
           end
+        end
+
+        # @api private
+        def with_listeners(listeners)
+          self.class.new(listeners)
         end
 
         private

--- a/core/lib/spree/event/listener.rb
+++ b/core/lib/spree/event/listener.rb
@@ -41,6 +41,11 @@ module Spree
         @exclusions << event_name
       end
 
+      # @api private
+      def listeners
+        [self]
+      end
+
       private
 
       def excludes?(event_name)

--- a/core/lib/spree/event/listener.rb
+++ b/core/lib/spree/event/listener.rb
@@ -14,13 +14,13 @@ module Spree
     #   Spree::Event.unsubscribe listener
     class Listener
       # @api private
-      attr_reader :pattern, :block
+      attr_reader :pattern, :block, :exclusions
 
       # @api private
-      def initialize(pattern:, block:)
+      def initialize(pattern:, block:, exclusions: [])
         @pattern = pattern
         @block = block
-        @exclusions = []
+        @exclusions = exclusions
       end
 
       # @api private
@@ -44,6 +44,15 @@ module Spree
       # @api private
       def listeners
         [self]
+      end
+
+      # @api private
+      def with_block(new_block)
+        self.class.new(
+          block: new_block,
+          pattern: pattern,
+          exclusions: exclusions
+        )
       end
 
       private

--- a/core/lib/spree/event/subscriber.rb
+++ b/core/lib/spree/event/subscriber.rb
@@ -81,6 +81,45 @@ module Spree
       def deactivate(event_action_name = nil)
         Spree::Event.subscriber_registry.deactivate_subscriber(self, event_action_name)
       end
+
+      # Returns the generated listeners for the subscriber
+      #
+      # When a {Subscriber} is registered, the corresponding listeners are
+      # automatically generated, i.e., the returning values for
+      # {Spree::Event.subscribe} that encapsulate the logic to be performed.
+      #
+      # The listeners to obtain can be restricted to only certain events by providing
+      # their names:
+      #
+      # @example
+      #
+      #   module EmailSender
+      #     include Spree::Event::Subscriber
+      #
+      #     event_action :order_finalized
+      #     event_action :confirm_reimbursement
+      #
+      #     def order_finalized(event)
+      #       # ...
+      #     end
+      #
+      #     def confirm_reimbursement(event)
+      #       # ...
+      #     end
+      #   end
+      #
+      #   EmailSender.activate
+      #   EmailSender.listeners.count # => 2
+      #   EmailSender.listeners("order_finalized").count # => 1
+      #
+      # @param event_names [Array<String, Symbol>]
+      # @return [Array<Spree::Event::Listener>] Take into account that
+      # {ActiveSupport::Notifications::Fanout::Subscribers::Timed} instances will
+      # be returned if the deprecated
+      # {Spree::Event::Adapters::ActiveSupportNotifications} adapter is used.
+      def listeners(*event_names)
+        Spree::Event.subscriber_registry.listeners(self, event_names: event_names)
+      end
     end
   end
 end

--- a/core/lib/spree/event/subscriber_registry.rb
+++ b/core/lib/spree/event/subscriber_registry.rb
@@ -50,6 +50,16 @@ module Spree
         end
       end
 
+      def listeners(subscriber, event_names: [])
+        registry[subscriber.name].values.yield_self do |listeners|
+          if event_names.empty?
+            listeners
+          else
+            listeners.select { |listener| event_names.map(&:to_s).include?(listener.pattern) }
+          end
+        end
+      end
+
       private
 
       attr_reader :registry

--- a/core/lib/spree/event/test_interface.rb
+++ b/core/lib/spree/event/test_interface.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'spree/event'
+
+module Spree
+  module Event
+    # Test helpers for {Spree::Event}
+    #
+    # This module defines test helpers methods that are made available to
+    # {Spree::Event} when {Spree::Event.enable_test_interface} is called.
+    module TestInterface
+      # Perform only given listeners for the duration of the block
+      #
+      # Temporarily deactivate all subscribed listeners and listen only to the
+      # provided ones for the duration of the block.
+      #
+      # @example
+      #   Spree::Event.enable_test_interface
+      #
+      #   listener1 = Spree::Event.subscribe('foo') { do_something }
+      #   listener2 = Spree::Event.subscribe('foo') { do_something_else }
+      #
+      #   Spree::Event.performing_only(listener1) do
+      #     Spree::Event.fire('foo') # This will run only `listener1`
+      #   end
+      #
+      #   Spree::Event.fire('foo') # This will run both `listener1` & `listener2`
+      #
+      # {Spree::Event::Subscriber} modules can also be given to unsubscribe from
+      # all listeners generated from it:
+      #
+      # @example
+      #   Spree::Event.performing_only(EmailSubscriber) {}
+      #
+      # You can gain more fine-grained control thanks to
+      # {Spree::Event::Subscribe#listeners}:
+      #
+      # @example
+      #   Spree::Event.performing_only(EmailSubscriber.listeners('order_finalized') {}
+      #
+      # You can mix different ways of specifying listeners without problems:
+      #
+      # @example
+      #   Spree::Event.performing_only(EmailSubscriber, listener1) {}
+      #
+      # @param listeners_and_subscribers [Spree::Event::Listener,
+      # Array<Spree::Event::Listener>, Spree::Event::Subscriber]
+      # @yield While the block executes only provided listeners will run
+      def performing_only(*listeners_and_subscribers)
+        old_adapter = default_adapter
+        listeners = listeners_and_subscribers.flatten.map(&:listeners)
+        Spree::Config.events.adapter = old_adapter.with_listeners(listeners.flatten)
+        yield
+        Spree::Config.events.adapter = old_adapter
+      end
+
+      # Perform no listeners for the duration of the block
+      #
+      # It's a specialized version of {#performing_only} that provides no
+      # listeners.
+      #
+      # @yield While the block executes no listeners will run
+      #
+      # @see Spree::Event::TestInterface#performing_only
+      def silenced(&block)
+        performing_only(&block)
+      end
+    end
+
+    # Adds test methods to {Spree::Event}
+    #
+    # @raise [RuntimeError] when {Spree::Event::Configuration#adapter} is set to
+    # the legacy adapter {Spree::Event::Adapters::ActiveSupportNotifications}.
+    def enable_test_interface
+      raise <<~MSG if legacy_adapter?(default_adapter)
+        Spree::Event's test interface is not supported when using the deprecated
+        adapter 'Spree::Event::Adapters::ActiveSupportNotifications'.
+      MSG
+
+      extend(TestInterface)
+    end
+  end
+end

--- a/core/spec/lib/spree/event/adapters/default_spec.rb
+++ b/core/spec/lib/spree/event/adapters/default_spec.rb
@@ -243,6 +243,37 @@ module Spree
             expect(dummy2.run).to be(true)
           end
         end
+
+        describe '#with_listeners' do
+          it 'returns a new instance with given listeners' do
+            bus = described_class.new
+            dummy1, dummy2, dummy3 = Array.new(3) do
+              Class.new do
+                attr_reader :run
+
+                def initialize
+                  @run = false
+                end
+
+                def toggle
+                  @run = true
+                end
+              end.new
+            end
+            listener1 = bus.subscribe('foo') { dummy1.toggle }
+            listener2 = bus.subscribe('foo') { dummy2.toggle }
+            listener3 = bus.subscribe('foo') { dummy3.toggle }
+
+            new_bus = bus.with_listeners([listener1, listener2])
+            new_bus.fire('foo')
+
+            expect(new_bus).not_to eq(bus)
+            expect(new_bus.listeners).to match_array([listener1, listener2])
+            expect(dummy1.run).to be(true)
+            expect(dummy2.run).to be(true)
+            expect(dummy3.run).to be(false)
+          end
+        end
       end
     end
   end

--- a/core/spec/lib/spree/event/listener_spec.rb
+++ b/core/spec/lib/spree/event/listener_spec.rb
@@ -71,4 +71,38 @@ RSpec.describe Spree::Event::Listener do
       expect(listener.listeners).to eq([listener])
     end
   end
+
+  describe '#with_block' do
+    it 'returns a new instance of a listener' do
+      listener = described_class.new(pattern: 'foo', block: -> {})
+
+      new_listener = listener.with_block(proc {})
+
+      expect(new_listener).not_to eq(listener)
+    end
+
+    it 'preserves pattern' do
+      listener = described_class.new(pattern: 'foo', block: -> {})
+
+      new_listener = listener.with_block(proc {})
+
+      expect(new_listener.pattern).to eq(listener.pattern)
+    end
+
+    it 'preserves exclusions' do
+      listener = described_class.new(pattern: 'foo', block: proc {}, exclusions: 'foo')
+
+      new_listener = listener.with_block(proc {})
+
+      expect(new_listener.exclusions).to eq(listener.exclusions)
+    end
+
+    it 'switches blocks' do
+      listener = described_class.new(pattern: 'foo', block: proc { :old_block }, exclusions: 'foo')
+
+      new_listener = listener.with_block(proc { :new_block })
+
+      expect(new_listener.call(:event)).to eq(:new_block)
+    end
+  end
 end

--- a/core/spec/lib/spree/event/listener_spec.rb
+++ b/core/spec/lib/spree/event/listener_spec.rb
@@ -63,4 +63,12 @@ RSpec.describe Spree::Event::Listener do
       end
     end
   end
+
+  describe '#listeners' do
+    it 'returns a list containing only itself' do
+      listener = described_class.new(pattern: 'foo', block: -> {})
+
+      expect(listener.listeners).to eq([listener])
+    end
+  end
 end

--- a/core/spec/lib/spree/event/subscriber_registry_spec.rb
+++ b/core/spec/lib/spree/event/subscriber_registry_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
+require 'rails_helper'
 require 'active_support/all'
 require 'spec_helper'
 require 'spree/event'
+require 'spree/event/listener'
 
 RSpec.describe Spree::Event::SubscriberRegistry do
   module N
@@ -110,6 +112,40 @@ RSpec.describe Spree::Event::SubscriberRegistry do
           end
         end
       end
+    end
+  end
+
+  describe '#listeners' do
+    before do
+      subject.register(N)
+      subject.activate_subscriber(N)
+    end
+    after { subject.deactivate_subscriber(N) }
+
+    it 'returns all listeners that the subscriber generates' do
+      listeners = subject.listeners(N)
+
+      expect(listeners.count).to be(2)
+      expect(listeners.first).to be_a(Spree::Event::Listener)
+    end
+
+    it 'can restrict by event names' do
+      listeners = subject.listeners(N, event_names: ['event_name'])
+
+      expect(listeners.count).to be(1)
+      expect(listeners.first.pattern).to eq('event_name')
+
+      listeners = subject.listeners(N, event_names: ['event_name', 'other_event'])
+
+      expect(listeners.count).to be(2)
+      expect(listeners.map(&:pattern)).to match(['event_name', 'other_event'])
+    end
+
+    it 'can event names as symbols' do
+      listeners = subject.listeners(N, event_names: [:event_name])
+
+      expect(listeners.count).to be(1)
+      expect(listeners.first.pattern).to eq('event_name')
     end
   end
 end

--- a/core/spec/lib/spree/event/test_interface_spec.rb
+++ b/core/spec/lib/spree/event/test_interface_spec.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spree/event/test_interface'
+
+RSpec.describe Spree::Event::TestInterface do
+  describe '#enable_test_interface' do
+    context 'when using the legacy adapter' do
+      it 'raises an error' do
+        adapter = Spree::Config.events.adapter
+        Spree::Config.events.adapter = Spree::Event::Adapters::ActiveSupportNotifications
+
+        expect {
+          Spree::Event.enable_test_interface
+        }.to raise_error(/test interface is not supported/)
+      ensure
+        Spree::Config.events.adapter = adapter
+      end
+    end
+  end
+
+  describe '#performing_only' do
+    before { Spree::Event.enable_test_interface }
+
+    it 'only performs given listeners for the duration of the block' do
+      dummy1, dummy2, dummy3 = Array.new(3) do
+        Class.new do
+          attr_reader :run
+
+          def initialize
+            @run = false
+          end
+
+          def toggle
+            @run = true
+          end
+        end.new
+      end
+      listener1 = Spree::Event.subscribe('foo') { dummy1.toggle }
+      listener2 = Spree::Event.subscribe('foo') { dummy2.toggle }
+      listener3 = Spree::Event.subscribe('foo') { dummy3.toggle }
+
+      Spree::Event.performing_only(listener1, listener2) do
+        Spree::Event.fire('foo')
+      end
+
+      expect(dummy1.run).to be(true)
+      expect(dummy2.run).to be(true)
+      expect(dummy3.run).to be(false)
+    ensure
+      Spree::Event.unsubscribe(listener1)
+      Spree::Event.unsubscribe(listener2)
+      Spree::Event.unsubscribe(listener3)
+    end
+
+    it 'performs again all the listeners once the block is done' do
+      dummy1, dummy2 = Array.new(2) do
+        Class.new do
+          attr_reader :run
+
+          def initialize
+            @run = false
+          end
+
+          def toggle
+            @run = true
+          end
+        end.new
+      end
+      listener1 = Spree::Event.subscribe('foo') { dummy1.toggle }
+      listener2 = Spree::Event.subscribe('foo') { dummy2.toggle }
+
+      Spree::Event.performing_only(listener1) do
+        Spree::Event.fire('foo')
+      end
+
+      expect(dummy1.run).to be(true)
+      expect(dummy2.run).to be(false)
+
+      Spree::Event.fire('foo')
+
+      expect(dummy2.run).to be(true)
+    ensure
+      Spree::Event.unsubscribe(listener1)
+      Spree::Event.unsubscribe(listener2)
+    end
+
+    it 'can extract listeners from a subscriber module' do
+      dummy1, dummy2 = Array.new(2) do
+        Class.new do
+          attr_reader :run
+
+          def initialize
+            @run = false
+          end
+
+          def toggle
+            @run = true
+          end
+        end.new
+      end
+      Subscriber1 = Module.new do
+        include Spree::Event::Subscriber
+
+        event_action :foo
+
+        def foo(event)
+          event.payload[:dummy1].toggle
+        end
+      end
+      Subscriber2 = Module.new do
+        include Spree::Event::Subscriber
+
+        event_action :foo
+
+        def foo(event)
+          event.payload[:dummy2].toggle
+        end
+      end
+      Spree::Event.subscriber_registry.register(Subscriber1)
+      Spree::Event.subscriber_registry.register(Subscriber2)
+      [Subscriber1, Subscriber2].map(&:activate)
+
+      Spree::Event.performing_only(Subscriber1) do
+        Spree::Event.fire('foo', dummy1: dummy1, dummy2: dummy2)
+      end
+
+      expect(dummy1.run).to be(true)
+      expect(dummy2.run).to be(false)
+    ensure
+      Spree::Event.subscriber_registry.deactivate_subscriber(Subscriber1)
+      Spree::Event.subscriber_registry.deactivate_subscriber(Subscriber2)
+    end
+
+    it 'can mix listeners and array of listeners' do
+      dummy1, dummy2 = Array.new(2) do 
+        Class.new do
+          attr_reader :run
+
+          def initialize
+            @run = false
+          end
+
+          def toggle
+            @run = true
+          end
+        end.new
+      end
+      listener = Spree::Event.subscribe('foo') { dummy1.toggle }
+      Subscriber = Module.new do
+        include Spree::Event::Subscriber
+
+        event_action :foo
+
+        def foo(event)
+          event.payload[:dummy2].toggle
+        end
+      end
+      Spree::Event.subscriber_registry.register(Subscriber)
+      Subscriber.activate
+
+      Spree::Event.performing_only(listener, Subscriber) do
+        Spree::Event.fire('foo', dummy2: dummy2)
+      end
+
+      expect(dummy1.run).to be(true)
+      expect(dummy2.run).to be(true)
+    ensure
+      Spree::Event.unsubscribe(listener)
+      Spree::Event.subscriber_registry.deactivate_subscriber(Subscriber)
+    end
+
+    it 'can perform no listener at all' do
+      dummy = Class.new do
+        attr_reader :run
+
+        def initialize
+          @run = false
+        end
+
+        def toggle
+          @run = true
+        end
+      end.new
+      listener = Spree::Event.subscribe('foo') { dummy.toggle }
+
+      Spree::Event.performing_only do
+        Spree::Event.fire('foo')
+      end
+
+      expect(dummy.run).to be(false)
+    ensure
+      Spree::Event.unsubscribe(listener)
+    end
+
+    it 'can override through an inner call' do
+      dummy = Class.new do
+        attr_reader :run
+
+        def initialize
+          @run = false
+        end
+
+        def toggle
+          @run = true
+        end
+      end.new
+      listener = Spree::Event.subscribe('foo') { dummy.toggle }
+
+      Spree::Event.performing_only do
+        Spree::Event.performing_only(listener) do
+          Spree::Event.fire('foo')
+        end
+      end
+
+      expect(dummy.run).to be(true)
+    ensure
+      Spree::Event.unsubscribe(listener)
+    end
+  end
+
+  describe '#silenced' do
+    before { Spree::Event.enable_test_interface }
+
+    it 'performs no listener for the duration of the block' do
+      dummy = Class.new do
+        attr_reader :run
+
+        def initialize
+          @run = false
+        end
+
+        def toggle
+          @run = true
+        end
+      end.new
+      listener = Spree::Event.subscribe('foo') { dummy.toggle }
+
+      Spree::Event.silenced do
+        Spree::Event.fire('foo')
+      end
+
+      expect(dummy.run).to be(false)
+    ensure
+      Spree::Event.unsubscribe(listener)
+    end
+  end
+end


### PR DESCRIPTION
**Description**

It's not uncommon for registered listeners to make calls to external
services. Injecting a more lightweight listener when you want to test
that the corresponding event is fired helps make the test suite faster
and self-contained. Example:

```ruby
Spree::Event.enable_test_interface
listener = ExternalServiceSubscriber.listeners('foo').first
external_service_called = false
mocked_listener = proc { external_service_called = true }

Spree::Event.performing_only(listener) do
  Spree::Event.inject_listeners(listener: mocked_listener) do
    code_firing_foo_event
  end
end

expect(external_service_called).to be(true)
```

The mapping between original listeners and the injected ones is bound to
the block so that more complex workflows are supported:

```ruby
Spree::Event.inject_listeners(listener: mocked_listener) do |mapping|
  Spree::Event.unsubscribe(mapping[listener])
end
```

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
