### PR TITLE
Enforce event registration

### DIFF
--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -44,6 +44,16 @@ module Spree
         Migrations.new(config, engine_name).check
       end
 
+      # Register core events
+      initializer 'spree.core.register_events' do
+        %w[
+          order_finalized
+          order_recalculated
+          reimbursement_reimbursed
+          reimbursement_errored
+        ].each { |event_name| Spree::Event.register(event_name) }
+      end
+
       # Setup Event Subscribers
       initializer 'spree.core.initialize_subscribers' do |app|
         app.reloader.to_prepare do

--- a/core/lib/spree/event.rb
+++ b/core/lib/spree/event.rb
@@ -4,6 +4,7 @@ require_relative 'event/adapters/active_support_notifications'
 require_relative 'event/subscriber_registry'
 require_relative 'event/configuration'
 require_relative 'event/subscriber'
+require 'spree/deprecation'
 
 module Spree
   # Event bus for Solidus.
@@ -11,6 +12,12 @@ module Spree
   # This module serves as the interface to access the Event Bus system in
   # Solidus. You can use different underlying adapters to provide the core
   # logic. It's recommended that you use {Spree::Event::Adapters::Default}.
+  #
+  # Before firing, subscribing, or unsubscribing an event, you need to
+  # {#register} it:
+  #
+  # @example
+  #   Spree::Event.register 'order_finalized'
   #
   # You use the {#fire} method to trigger an event:
   #
@@ -41,6 +48,31 @@ module Spree
     extend self
 
     delegate :activate_autoloadable_subscribers, :activate_all_subscribers, :deactivate_all_subscribers, to: :subscriber_registry
+
+    # Registers an event
+    #
+    # This step is needed before firing, subscribing or unsubscribing an
+    # event. It helps to prevent typos and naming collision.
+    #
+    # This method is not available in the legacy adapter.
+    #
+    # @example
+    #   Spree::Event.register('foo')
+    #
+    # @param [String, Symbol] event_name
+    # @param [Any] adapter the event bus adapter to use.
+    def register(event_name, adapter: default_adapter)
+      return warn_registration_on_legacy_adapter if legacy_adapter?(adapter)
+
+      adapter.register(normalize_name(event_name), caller_location: caller_locations(1)[0])
+    end
+
+    # @api private
+    def registry(adapter: default_adapter)
+      return warn_registration_on_legacy_adapter if legacy_adapter?(adapter)
+
+      adapter.registry
+    end
 
     # Allows to trigger events that can be subscribed using {#subscribe}.
     #
@@ -237,6 +269,13 @@ module Spree
 
         MSG
       end
+    end
+
+    def warn_registration_on_legacy_adapter
+      Spree::Deprecation.warn <<~MSG
+        Event registration works only on the new adapter
+        `Spree::Event::Adapter::Default`. Please, update to it.
+      MSG
     end
 
     def legacy_adapter?(adapter)

--- a/core/lib/spree/event/adapters/default.rb
+++ b/core/lib/spree/event/adapters/default.rb
@@ -2,6 +2,7 @@
 
 require 'spree/event/event'
 require 'spree/event/listener'
+require 'spree/event/registry'
 
 module Spree
   module Event
@@ -25,14 +26,21 @@ module Spree
       # be the default one.
       class Default
         # @api private
-        attr_reader :listeners
+        attr_reader :listeners, :registry
 
-        def initialize(listeners = [])
+        def initialize(listeners = [], registry = Registry.new)
           @listeners = listeners
+          @registry = registry
+        end
+
+        # @api private
+        def register(event_name, caller_location: caller_locations(1)[0])
+          registry.register(event_name, caller_location: caller_location)
         end
 
         # @api private
         def fire(event_name, opts = {})
+          registry.check_event_name_registered(event_name)
           Event.new(payload: opts).tap do |event|
             listeners_for_event(event_name).each do |listener|
               listener.call(event)
@@ -42,6 +50,7 @@ module Spree
 
         # @api private
         def subscribe(event_name_or_regexp, &block)
+          registry.check_event_name_registered(event_name_or_regexp) if event_name?(event_name_or_regexp)
           Listener.new(pattern: event_name_or_regexp, block: block).tap do |listener|
             @listeners << listener
           end
@@ -52,13 +61,14 @@ module Spree
           if subscriber_or_event_name.is_a?(Listener)
             unsubscribe_listener(subscriber_or_event_name)
           else
+            registry.check_event_name_registered(subscriber_or_event_name) if event_name?(subscriber_or_event_name)
             unsubscribe_event(subscriber_or_event_name)
           end
         end
 
         # @api private
         def with_listeners(listeners)
-          self.class.new(listeners)
+          self.class.new(listeners, registry)
         end
 
         private
@@ -77,6 +87,10 @@ module Spree
           @listeners.each do |listener|
             listener.unsubscribe(event_name)
           end
+        end
+
+        def event_name?(candidate)
+          candidate.is_a?(String)
         end
       end
     end

--- a/core/lib/spree/event/adapters/default.rb
+++ b/core/lib/spree/event/adapters/default.rb
@@ -27,8 +27,8 @@ module Spree
         # @api private
         attr_reader :listeners
 
-        def initialize
-          @listeners = []
+        def initialize(listeners = [])
+          @listeners = listeners
         end
 
         # @api private
@@ -54,6 +54,11 @@ module Spree
           else
             unsubscribe_event(subscriber_or_event_name)
           end
+        end
+
+        # @api private
+        def with_listeners(listeners)
+          self.class.new(listeners)
         end
 
         private

--- a/core/lib/spree/event/configuration.rb
+++ b/core/lib/spree/event/configuration.rb
@@ -49,7 +49,7 @@ module Spree
 
           That will be the new default on Solidus 4.
 
-          Take into account there're two critical changes in behavior in the new adapter:
+          Take into account there're three critical changes in behavior in the new adapter:
 
           - Event names are no longer automatically suffixed with `.spree`, as
           they're no longer in the same bucket that Rails's ones. So, for
@@ -73,6 +73,12 @@ module Spree
 
             order.do_something
             Spree::Event.fire 'event_name', order: order
+
+          - You need to register your custom events before firing or subscribing
+            to them (no need for Solidus' custom ones). Example:
+
+              Spree::Event.register('foo')
+              Spree::Event.fire('foo')
 
         MSG
       end

--- a/core/lib/spree/event/listener.rb
+++ b/core/lib/spree/event/listener.rb
@@ -41,6 +41,11 @@ module Spree
         @exclusions << event_name
       end
 
+      # @api private
+      def listeners
+        [self]
+      end
+
       private
 
       def excludes?(event_name)

--- a/core/lib/spree/event/registry.rb
+++ b/core/lib/spree/event/registry.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Spree
+  module Event
+    # Registry of known events
+    #
+    # @api privte
+    class Registry
+      class Registration
+        attr_reader :event_name, :caller_location
+
+        def initialize(event_name:, caller_location:)
+          @event_name = event_name
+          @caller_location = caller_location
+        end
+      end
+
+      attr_reader :registrations
+
+      def initialize(registrations: [])
+        @registrations = registrations
+      end
+
+      def register(event_name, caller_location: caller_locations(1)[0])
+        registration = registration(event_name)
+        if registration
+          raise <<~MSG
+            Can't register #{event_name} event as it's already registered.
+
+            The registration happened at:
+
+            #{registration.caller_location}
+          MSG
+        else
+          @registrations << Registration.new(event_name: event_name, caller_location: caller_location)
+        end
+      end
+
+      def unregister(event_name)
+        raise <<~MSG unless registered?(event_name)
+          #{event_name} is not registered.
+
+          Known events are:
+
+            '#{event_names.join("' '")}'
+        MSG
+
+        @registrations.delete_if { |regs| regs.event_name == event_name }
+      end
+
+      def registration(event_name)
+        registrations.find { |reg| reg.event_name == event_name }
+      end
+
+      def registered?(event_name)
+        !registration(event_name).nil?
+      end
+
+      def event_names
+        registrations.map(&:event_name)
+      end
+
+      def check_event_name_registered(event_name)
+        return true if registered?(event_name)
+
+        raise <<~MSG
+            '#{event_name}' is not registered as a valid event name.
+            #{suggestions_message(event_name)}
+
+            All known events are:
+
+              '#{event_names.join(" ")}'
+
+            You can register the new event with:
+
+              Spree::Event.register('#{event_name}')
+        MSG
+      end
+
+      private
+
+      def suggestions(event_name)
+        dictionary = DidYouMean::SpellChecker.new(dictionary: event_names)
+
+        dictionary.correct(event_name)
+      end
+
+      def suggestions_message(event_name)
+        DidYouMean::PlainFormatter.new.message_for(suggestions(event_name))
+      end
+    end
+  end
+end

--- a/core/lib/spree/event/subscriber.rb
+++ b/core/lib/spree/event/subscriber.rb
@@ -81,6 +81,45 @@ module Spree
       def deactivate(event_action_name = nil)
         Spree::Event.subscriber_registry.deactivate_subscriber(self, event_action_name)
       end
+
+      # Returns the generated listeners for the subscriber
+      #
+      # When a {Subscriber} is registered, the corresponding listeners are
+      # automatically generated, i.e., the returning values for
+      # {Spree::Event.subscribe} that encapsulate the logic to be performed.
+      #
+      # The listeners to obtain can be restricted to only certain events by providing
+      # their names:
+      #
+      # @example
+      #
+      #   module EmailSender
+      #     include Spree::Event::Subscriber
+      #
+      #     event_action :order_finalized
+      #     event_action :confirm_reimbursement
+      #
+      #     def order_finalized(event)
+      #       # ...
+      #     end
+      #
+      #     def confirm_reimbursement(event)
+      #       # ...
+      #     end
+      #   end
+      #
+      #   EmailSender.activate
+      #   EmailSender.listeners.count # => 2
+      #   EmailSender.listeners("order_finalized").count # => 1
+      #
+      # @param event_names [Array<String, Symbol>]
+      # @return [Array<Spree::Event::Listener>] Take into account that
+      # {ActiveSupport::Notifications::Fanout::Subscribers::Timed} instances will
+      # be returned if the deprecated
+      # {Spree::Event::Adapters::ActiveSupportNotifications} adapter is used.
+      def listeners(*event_names)
+        Spree::Event.subscriber_registry.listeners(self, event_names: event_names)
+      end
     end
   end
 end

--- a/core/lib/spree/event/subscriber_registry.rb
+++ b/core/lib/spree/event/subscriber_registry.rb
@@ -50,6 +50,16 @@ module Spree
         end
       end
 
+      def listeners(subscriber, event_names: [])
+        registry[subscriber.name].values.yield_self do |listeners|
+          if event_names.empty?
+            listeners
+          else
+            listeners.select { |listener| event_names.map(&:to_s).include?(listener.pattern) }
+          end
+        end
+      end
+
       private
 
       attr_reader :registry

--- a/core/lib/spree/event/test_interface.rb
+++ b/core/lib/spree/event/test_interface.rb
@@ -65,6 +65,13 @@ module Spree
       def silenced(&block)
         performing_only(&block)
       end
+
+      # Unregisters a previously registered event
+      #
+      # @param [String, Symbol] event_name
+      def unregister(event_name)
+        registry.unregister(normalize_name(event_name))
+      end
     end
 
     # Adds test methods to {Spree::Event}

--- a/core/lib/spree/event/test_interface.rb
+++ b/core/lib/spree/event/test_interface.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'spree/event'
+
+module Spree
+  module Event
+    # Test helpers for {Spree::Event}
+    #
+    # This module defines test helpers methods that are made available to
+    # {Spree::Event} when {Spree::Event.enable_test_interface} is called.
+    module TestInterface
+      # Perform only given listeners for the duration of the block
+      #
+      # Temporarily deactivate all subscribed listeners and listen only to the
+      # provided ones for the duration of the block.
+      #
+      # @example
+      #   Spree::Event.enable_test_interface
+      #
+      #   listener1 = Spree::Event.subscribe('foo') { do_something }
+      #   listener2 = Spree::Event.subscribe('foo') { do_something_else }
+      #
+      #   Spree::Event.performing_only(listener1) do
+      #     Spree::Event.fire('foo') # This will run only `listener1`
+      #   end
+      #
+      #   Spree::Event.fire('foo') # This will run both `listener1` & `listener2`
+      #
+      # {Spree::Event::Subscriber} modules can also be given to unsubscribe from
+      # all listeners generated from it:
+      #
+      # @example
+      #   Spree::Event.performing_only(EmailSubscriber) {}
+      #
+      # You can gain more fine-grained control thanks to
+      # {Spree::Event::Subscribe#listeners}:
+      #
+      # @example
+      #   Spree::Event.performing_only(EmailSubscriber.listeners('order_finalized') {}
+      #
+      # You can mix different ways of specifying listeners without problems:
+      #
+      # @example
+      #   Spree::Event.performing_only(EmailSubscriber, listener1) {}
+      #
+      # @param listeners_and_subscribers [Spree::Event::Listener,
+      # Array<Spree::Event::Listener>, Spree::Event::Subscriber]
+      # @yield While the block executes only provided listeners will run
+      def performing_only(*listeners_and_subscribers)
+        old_adapter = default_adapter
+        listeners = listeners_and_subscribers.flatten.map(&:listeners)
+        Spree::Config.events.adapter = old_adapter.with_listeners(listeners.flatten)
+        yield
+        Spree::Config.events.adapter = old_adapter
+      end
+
+      # Perform no listeners for the duration of the block
+      #
+      # It's a specialized version of {#performing_only} that provides no
+      # listeners.
+      #
+      # @yield While the block executes no listeners will run
+      #
+      # @see Spree::Event::TestInterface#performing_only
+      def silenced(&block)
+        performing_only(&block)
+      end
+    end
+
+    # Adds test methods to {Spree::Event}
+    #
+    # @raise [RuntimeError] when {Spree::Event::Configuration#adapter} is set to
+    # the legacy adapter {Spree::Event::Adapters::ActiveSupportNotifications}.
+    def enable_test_interface
+      raise <<~MSG if legacy_adapter?(default_adapter)
+        Spree::Event's test interface is not supported when using the deprecated
+        adapter 'Spree::Event::Adapters::ActiveSupportNotifications'.
+      MSG
+
+      extend(TestInterface)
+    end
+  end
+end

--- a/core/spec/lib/spree/event/adapters/default_spec.rb
+++ b/core/spec/lib/spree/event/adapters/default_spec.rb
@@ -243,6 +243,37 @@ module Spree
             expect(dummy2.run).to be(true)
           end
         end
+
+        describe '#with_listeners' do
+          it 'returns a new instance with given listeners' do
+            bus = described_class.new
+            dummy1, dummy2, dummy3 = Array.new(3) do
+              Class.new do
+                attr_reader :run
+
+                def initialize
+                  @run = false
+                end
+
+                def toggle
+                  @run = true
+                end
+              end.new
+            end
+            listener1 = bus.subscribe('foo') { dummy1.toggle }
+            listener2 = bus.subscribe('foo') { dummy2.toggle }
+            listener3 = bus.subscribe('foo') { dummy3.toggle }
+
+            new_bus = bus.with_listeners([listener1, listener2])
+            new_bus.fire('foo')
+
+            expect(new_bus).not_to eq(bus)
+            expect(new_bus.listeners).to match_array([listener1, listener2])
+            expect(dummy1.run).to be(true)
+            expect(dummy2.run).to be(true)
+            expect(dummy3.run).to be(false)
+          end
+        end
       end
     end
   end

--- a/core/spec/lib/spree/event/listener_spec.rb
+++ b/core/spec/lib/spree/event/listener_spec.rb
@@ -63,4 +63,12 @@ RSpec.describe Spree::Event::Listener do
       end
     end
   end
+
+  describe '#listeners' do
+    it 'returns a list containing only itself' do
+      listener = described_class.new(pattern: 'foo', block: -> {})
+
+      expect(listener.listeners).to eq([listener])
+    end
+  end
 end

--- a/core/spec/lib/spree/event/registry_spec.rb
+++ b/core/spec/lib/spree/event/registry_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'spree/event/registry'
+
+RSpec.describe Spree::Event::Registry do
+  describe '#register' do
+    it 'adds given event name to the registry' do
+      registry = described_class.new
+
+      registry.register('foo')
+
+      expect(registry.registered?('foo')).to be(true)
+    end
+
+    it 'adds given caller location to the registration' do
+      registry = described_class.new
+
+      registry.register('foo', caller_location: caller_locations(0)[0])
+
+      expect(registry.registration('foo').caller_location.to_s).to include(__FILE__)
+    end
+
+    it 'raises with the registration location info when the event has already been registered' do
+      registry = described_class.new
+
+      registry.register('foo', caller_location: caller_locations(0)[0])
+
+      expect {
+        registry.register('foo', caller_location: caller_locations(2)[0])
+      }.to raise_error(/already registered.*#{__FILE__}/m)
+    end
+  end
+
+  describe '#unregister' do
+    it 'removes given event name from the registry' do
+      registry = described_class.new
+      registry.register('foo')
+
+      registry.unregister('foo')
+
+      expect(registry.registered?('foo')).to be(false)
+    end
+
+    it "raises when the event hasn't been registered" do
+      registry = described_class.new
+      registry.register('bar')
+
+      expect {
+        registry.unregister('foo')
+      }.to raise_error(/not registered.*bar/m)
+    end
+  end
+
+  describe '#registration' do
+    it 'finds the registration from given name' do
+      registry = described_class.new
+
+      registry.register('foo')
+
+      expect(registry.registration('foo').event_name).to eq('foo')
+    end
+
+    it 'returns nil when the event name is not found' do
+      registry = described_class.new
+
+      expect(registry.registration('foo')).to be_nil
+    end
+  end
+
+  describe '#registered?' do
+    it 'returns true when given event name is registered' do
+      registry = described_class.new
+      registry.register('foo')
+
+      expect(registry.registered?('foo')).to be(true)
+    end
+
+    it 'returns false when given event name is not registered' do
+      registry = described_class.new
+
+      expect(registry.registered?('foo')).to be(false)
+    end
+  end
+
+  describe '#event_names' do
+    it 'returns array with the registered event names' do
+      registry = described_class.new
+      registry.register('foo')
+      registry.register('bar')
+
+      expect(registry.event_names).to match_array(['foo', 'bar'])
+    end
+  end
+
+  describe '#check_event_name_registered' do
+    it 'returns true if the event is registered' do
+      registry = described_class.new
+      registry.register('foo')
+
+      expect(registry.check_event_name_registered('foo')).to be(true)
+    end
+
+    it 'raises when the event is not registered' do
+      registry = described_class.new
+
+      expect {
+        registry.check_event_name_registered('foo')
+      }.to raise_error(/not registered/)
+    end
+
+    it 'includes all available events on the error message' do
+      registry = described_class.new
+      registry.register('bar')
+      registry.register('baz')
+
+      expect {
+        registry.check_event_name_registered('foo')
+      }.to raise_error(/bar.*baz/)
+    end
+
+    it 'hints on the event name on the error message' do
+      registry = described_class.new
+      registry.register('order_canceled')
+
+      expect {
+        registry.check_event_name_registered('order_canceed')
+      }.to raise_error(/Did you mean\?  order_canceled/)
+    end
+  end
+end

--- a/core/spec/lib/spree/event/subscriber_registry_spec.rb
+++ b/core/spec/lib/spree/event/subscriber_registry_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe Spree::Event::SubscriberRegistry do
     end
   end
 
+  before do
+    Spree::Event.register(:event_name)
+    Spree::Event.register(:other_event)
+  end
+
+  after do
+    Spree::Event.unregister(:event_name)
+    Spree::Event.unregister(:other_event)
+  end
+
   describe "#activate_all_subscribers" do
     before { subject.register(N) }
 

--- a/core/spec/lib/spree/event/subscriber_registry_spec.rb
+++ b/core/spec/lib/spree/event/subscriber_registry_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
+require 'rails_helper'
 require 'active_support/all'
 require 'spec_helper'
 require 'spree/event'
+require 'spree/event/listener'
 
 RSpec.describe Spree::Event::SubscriberRegistry do
   module N
@@ -110,6 +112,40 @@ RSpec.describe Spree::Event::SubscriberRegistry do
           end
         end
       end
+    end
+  end
+
+  describe '#listeners' do
+    before do
+      subject.register(N)
+      subject.activate_subscriber(N)
+    end
+    after { subject.deactivate_subscriber(N) }
+
+    it 'returns all listeners that the subscriber generates' do
+      listeners = subject.listeners(N)
+
+      expect(listeners.count).to be(2)
+      expect(listeners.first).to be_a(Spree::Event::Listener)
+    end
+
+    it 'can restrict by event names' do
+      listeners = subject.listeners(N, event_names: ['event_name'])
+
+      expect(listeners.count).to be(1)
+      expect(listeners.first.pattern).to eq('event_name')
+
+      listeners = subject.listeners(N, event_names: ['event_name', 'other_event'])
+
+      expect(listeners.count).to be(2)
+      expect(listeners.map(&:pattern)).to match(['event_name', 'other_event'])
+    end
+
+    it 'can event names as symbols' do
+      listeners = subject.listeners(N, event_names: [:event_name])
+
+      expect(listeners.count).to be(1)
+      expect(listeners.first.pattern).to eq('event_name')
     end
   end
 end

--- a/core/spec/lib/spree/event/subscriber_spec.rb
+++ b/core/spec/lib/spree/event/subscriber_spec.rb
@@ -7,6 +7,16 @@ require 'spree/event'
 require 'spree/event/listener'
 
 RSpec.describe Spree::Event::Subscriber do
+  before do
+    Spree::Event.register(:event_name)
+    Spree::Event.register(:foo)
+  end
+
+  after do
+    Spree::Event.unregister(:event_name)
+    Spree::Event.unregister(:foo)
+  end
+
   module M
     include Spree::Event::Subscriber
 
@@ -69,12 +79,18 @@ RSpec.describe Spree::Event::Subscriber do
 
       it 'does not subscribe the action' do
         expect(M).not_to receive(:other_event)
+        Spree::Event.register('other_event')
+
         Spree::Event.fire 'other_event'
+
+      ensure
+        Spree::Event.unregister('other_event')
       end
     end
 
     context 'when the action is declared' do
       before do
+        Spree::Event.register('other_event')
         M.event_action :other_event
         M.activate
       end
@@ -82,6 +98,7 @@ RSpec.describe Spree::Event::Subscriber do
       after do
         M.deactivate
         M.event_actions.delete(:other_event)
+        Spree::Event.unregister('other_event')
       end
 
       it 'subscribe the action' do

--- a/core/spec/lib/spree/event/test_interface_spec.rb
+++ b/core/spec/lib/spree/event/test_interface_spec.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'spree/event/test_interface'
+
+RSpec.describe Spree::Event::TestInterface do
+  describe '#enable_test_interface' do
+    context 'when using the legacy adapter' do
+      it 'raises an error' do
+        adapter = Spree::Config.events.adapter
+        Spree::Config.events.adapter = Spree::Event::Adapters::ActiveSupportNotifications
+
+        expect {
+          Spree::Event.enable_test_interface
+        }.to raise_error(/test interface is not supported/)
+      ensure
+        Spree::Config.events.adapter = adapter
+      end
+    end
+  end
+
+  describe '#performing_only' do
+    before { Spree::Event.enable_test_interface }
+
+    it 'only performs given listeners for the duration of the block' do
+      dummy1, dummy2, dummy3 = Array.new(3) do
+        Class.new do
+          attr_reader :run
+
+          def initialize
+            @run = false
+          end
+
+          def toggle
+            @run = true
+          end
+        end.new
+      end
+      listener1 = Spree::Event.subscribe('foo') { dummy1.toggle }
+      listener2 = Spree::Event.subscribe('foo') { dummy2.toggle }
+      listener3 = Spree::Event.subscribe('foo') { dummy3.toggle }
+
+      Spree::Event.performing_only(listener1, listener2) do
+        Spree::Event.fire('foo')
+      end
+
+      expect(dummy1.run).to be(true)
+      expect(dummy2.run).to be(true)
+      expect(dummy3.run).to be(false)
+    ensure
+      Spree::Event.unsubscribe(listener1)
+      Spree::Event.unsubscribe(listener2)
+      Spree::Event.unsubscribe(listener3)
+    end
+
+    it 'performs again all the listeners once the block is done' do
+      dummy1, dummy2 = Array.new(2) do
+        Class.new do
+          attr_reader :run
+
+          def initialize
+            @run = false
+          end
+
+          def toggle
+            @run = true
+          end
+        end.new
+      end
+      listener1 = Spree::Event.subscribe('foo') { dummy1.toggle }
+      listener2 = Spree::Event.subscribe('foo') { dummy2.toggle }
+
+      Spree::Event.performing_only(listener1) do
+        Spree::Event.fire('foo')
+      end
+
+      expect(dummy1.run).to be(true)
+      expect(dummy2.run).to be(false)
+
+      Spree::Event.fire('foo')
+
+      expect(dummy2.run).to be(true)
+    ensure
+      Spree::Event.unsubscribe(listener1)
+      Spree::Event.unsubscribe(listener2)
+    end
+
+    it 'can extract listeners from a subscriber module' do
+      dummy1, dummy2 = Array.new(2) do
+        Class.new do
+          attr_reader :run
+
+          def initialize
+            @run = false
+          end
+
+          def toggle
+            @run = true
+          end
+        end.new
+      end
+      Subscriber1 = Module.new do
+        include Spree::Event::Subscriber
+
+        event_action :foo
+
+        def foo(event)
+          event.payload[:dummy1].toggle
+        end
+      end
+      Subscriber2 = Module.new do
+        include Spree::Event::Subscriber
+
+        event_action :foo
+
+        def foo(event)
+          event.payload[:dummy2].toggle
+        end
+      end
+      Spree::Event.subscriber_registry.register(Subscriber1)
+      Spree::Event.subscriber_registry.register(Subscriber2)
+      [Subscriber1, Subscriber2].map(&:activate)
+
+      Spree::Event.performing_only(Subscriber1) do
+        Spree::Event.fire('foo', dummy1: dummy1, dummy2: dummy2)
+      end
+
+      expect(dummy1.run).to be(true)
+      expect(dummy2.run).to be(false)
+    ensure
+      Spree::Event.subscriber_registry.deactivate_subscriber(Subscriber1)
+      Spree::Event.subscriber_registry.deactivate_subscriber(Subscriber2)
+    end
+
+    it 'can mix listeners and array of listeners' do
+      dummy1, dummy2 = Array.new(2) do 
+        Class.new do
+          attr_reader :run
+
+          def initialize
+            @run = false
+          end
+
+          def toggle
+            @run = true
+          end
+        end.new
+      end
+      listener = Spree::Event.subscribe('foo') { dummy1.toggle }
+      Subscriber = Module.new do
+        include Spree::Event::Subscriber
+
+        event_action :foo
+
+        def foo(event)
+          event.payload[:dummy2].toggle
+        end
+      end
+      Spree::Event.subscriber_registry.register(Subscriber)
+      Subscriber.activate
+
+      Spree::Event.performing_only(listener, Subscriber) do
+        Spree::Event.fire('foo', dummy2: dummy2)
+      end
+
+      expect(dummy1.run).to be(true)
+      expect(dummy2.run).to be(true)
+    ensure
+      Spree::Event.unsubscribe(listener)
+      Spree::Event.subscriber_registry.deactivate_subscriber(Subscriber)
+    end
+
+    it 'can perform no listener at all' do
+      dummy = Class.new do
+        attr_reader :run
+
+        def initialize
+          @run = false
+        end
+
+        def toggle
+          @run = true
+        end
+      end.new
+      listener = Spree::Event.subscribe('foo') { dummy.toggle }
+
+      Spree::Event.performing_only do
+        Spree::Event.fire('foo')
+      end
+
+      expect(dummy.run).to be(false)
+    ensure
+      Spree::Event.unsubscribe(listener)
+    end
+
+    it 'can override through an inner call' do
+      dummy = Class.new do
+        attr_reader :run
+
+        def initialize
+          @run = false
+        end
+
+        def toggle
+          @run = true
+        end
+      end.new
+      listener = Spree::Event.subscribe('foo') { dummy.toggle }
+
+      Spree::Event.performing_only do
+        Spree::Event.performing_only(listener) do
+          Spree::Event.fire('foo')
+        end
+      end
+
+      expect(dummy.run).to be(true)
+    ensure
+      Spree::Event.unsubscribe(listener)
+    end
+  end
+
+  describe '#silenced' do
+    before { Spree::Event.enable_test_interface }
+
+    it 'performs no listener for the duration of the block' do
+      dummy = Class.new do
+        attr_reader :run
+
+        def initialize
+          @run = false
+        end
+
+        def toggle
+          @run = true
+        end
+      end.new
+      listener = Spree::Event.subscribe('foo') { dummy.toggle }
+
+      Spree::Event.silenced do
+        Spree::Event.fire('foo')
+      end
+
+      expect(dummy.run).to be(false)
+    ensure
+      Spree::Event.unsubscribe(listener)
+    end
+  end
+end

--- a/core/spec/lib/spree/event/test_interface_spec.rb
+++ b/core/spec/lib/spree/event/test_interface_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Spree::Event::TestInterface do
           end
         end.new
       end
+      Spree::Event.register('foo')
       listener1 = Spree::Event.subscribe('foo') { dummy1.toggle }
       listener2 = Spree::Event.subscribe('foo') { dummy2.toggle }
       listener3 = Spree::Event.subscribe('foo') { dummy3.toggle }
@@ -51,6 +52,7 @@ RSpec.describe Spree::Event::TestInterface do
       Spree::Event.unsubscribe(listener1)
       Spree::Event.unsubscribe(listener2)
       Spree::Event.unsubscribe(listener3)
+      Spree::Event.unregister('foo')
     end
 
     it 'performs again all the listeners once the block is done' do
@@ -67,6 +69,7 @@ RSpec.describe Spree::Event::TestInterface do
           end
         end.new
       end
+      Spree::Event.register('foo')
       listener1 = Spree::Event.subscribe('foo') { dummy1.toggle }
       listener2 = Spree::Event.subscribe('foo') { dummy2.toggle }
 
@@ -83,6 +86,7 @@ RSpec.describe Spree::Event::TestInterface do
     ensure
       Spree::Event.unsubscribe(listener1)
       Spree::Event.unsubscribe(listener2)
+      Spree::Event.unregister('foo')
     end
 
     it 'can extract listeners from a subscriber module' do
@@ -99,6 +103,7 @@ RSpec.describe Spree::Event::TestInterface do
           end
         end.new
       end
+      Spree::Event.register('foo')
       Subscriber1 = Module.new do
         include Spree::Event::Subscriber
 
@@ -130,6 +135,7 @@ RSpec.describe Spree::Event::TestInterface do
     ensure
       Spree::Event.subscriber_registry.deactivate_subscriber(Subscriber1)
       Spree::Event.subscriber_registry.deactivate_subscriber(Subscriber2)
+      Spree::Event.unregister('foo')
     end
 
     it 'can mix listeners and array of listeners' do
@@ -146,6 +152,7 @@ RSpec.describe Spree::Event::TestInterface do
           end
         end.new
       end
+      Spree::Event.register('foo')
       listener = Spree::Event.subscribe('foo') { dummy1.toggle }
       Subscriber = Module.new do
         include Spree::Event::Subscriber
@@ -168,6 +175,7 @@ RSpec.describe Spree::Event::TestInterface do
     ensure
       Spree::Event.unsubscribe(listener)
       Spree::Event.subscriber_registry.deactivate_subscriber(Subscriber)
+      Spree::Event.unregister('foo')
     end
 
     it 'can perform no listener at all' do
@@ -182,6 +190,7 @@ RSpec.describe Spree::Event::TestInterface do
           @run = true
         end
       end.new
+      Spree::Event.register('foo')
       listener = Spree::Event.subscribe('foo') { dummy.toggle }
 
       Spree::Event.performing_only do
@@ -191,6 +200,7 @@ RSpec.describe Spree::Event::TestInterface do
       expect(dummy.run).to be(false)
     ensure
       Spree::Event.unsubscribe(listener)
+      Spree::Event.unregister('foo')
     end
 
     it 'can override through an inner call' do
@@ -205,6 +215,7 @@ RSpec.describe Spree::Event::TestInterface do
           @run = true
         end
       end.new
+      Spree::Event.register('foo')
       listener = Spree::Event.subscribe('foo') { dummy.toggle }
 
       Spree::Event.performing_only do
@@ -216,6 +227,7 @@ RSpec.describe Spree::Event::TestInterface do
       expect(dummy.run).to be(true)
     ensure
       Spree::Event.unsubscribe(listener)
+      Spree::Event.unregister('foo')
     end
   end
 
@@ -234,6 +246,7 @@ RSpec.describe Spree::Event::TestInterface do
           @run = true
         end
       end.new
+      Spree::Event.register('foo')
       listener = Spree::Event.subscribe('foo') { dummy.toggle }
 
       Spree::Event.silenced do
@@ -243,6 +256,31 @@ RSpec.describe Spree::Event::TestInterface do
       expect(dummy.run).to be(false)
     ensure
       Spree::Event.unsubscribe(listener)
+      Spree::Event.unregister('foo')
+    end
+  end
+
+  describe '#unregister_event' do
+    before { Spree::Event.enable_test_interface }
+
+    it 'unregisters an event from the registry' do
+      Spree::Event.register('foo')
+
+      Spree::Event.unregister('foo')
+
+      expect {
+        Spree::Event.fire('foo')
+      }.to raise_error(/not registered/)
+    end
+
+    it 'coercers names given as symbol' do
+      Spree::Event.register('foo')
+
+      Spree::Event.unregister(:foo)
+
+      expect {
+        Spree::Event.fire('foo')
+      }.to raise_error(/not registered/)
     end
   end
 end

--- a/core/spec/rails_helper.rb
+++ b/core/spec/rails_helper.rb
@@ -9,6 +9,8 @@ DummyApp.setup(
   gem_root: File.expand_path('..', __dir__),
   lib_name: 'solidus_core'
 )
+require 'spree/event/test_interface'
+Spree::Event.enable_test_interface
 
 require 'rspec/rails'
 require 'rspec-activemodel-mocks'


### PR DESCRIPTION
**Description**

Make it mandatory to register an event before being fired, subscribed
to, or unsubscribed from.

It helps with two scenarios:

- It avoids typo errors, like subscribing to an event `ordr_finalized`
  instead of `order_finalized`.

- It avoids naming collisions between user-defined events and core ones.

Example:

```ruby
Spree::Event.register('foo')
Spree::Event.fire('foo')
```

We add this behavior only to the new, recommended adapter. However, we
add into the deprecation error for the legacy adapter the instructions
to update.

We also add a new `#unregister` method for the test interface so that we
can't avoid polluting the global bus.


**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [ ] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [ ] I have attached screenshots to this PR for visual changes (if needed)
