### PR TITLE
Add rake task to import current Roles to new permission system

### DIFF
--- a/core/lib/tasks/solidus/import_existing_permission_sets.rake
+++ b/core/lib/tasks/solidus/import_existing_permission_sets.rake
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+namespace :solidus do
+  desc "Import existing permission sets to role permissions table"
+  task import_existing_permission_sets: :environment do
+    Zeitwerk::Loader.eager_load_all unless Rails.env.test?
+
+    ActiveRecord::Base.transaction do
+      Spree::PermissionSets::Base.descendants.each do |permission|
+        Spree::PermissionSet.find_or_create_by(name: permission.to_s.split('PermissionSets::').last.underscore, set: permission.to_s)
+      end
+
+      Spree::AppConfiguration.new.roles.roles.each do |role_name, role_config|
+        role_config.permission_sets.each do |set|
+          role = Spree::Role.find_or_create_by(name: role_name)
+          permission_set = Spree::PermissionSet.find_by(set: set.name)
+
+          if permission_set
+            Spree::RolePermission.find_or_create_by!(
+              role: role,
+              permission_set: permission_set
+            )
+          else
+            puts "#{set} was not found."
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/spec/lib/tasks/solidus/import_existing_permission_sets_spec.rb
+++ b/core/spec/lib/tasks/solidus/import_existing_permission_sets_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+path = Spree::Core::Engine.root.join('lib/tasks/solidus/import_existing_permission_sets.rake')
+
+RSpec.describe 'solidus' do
+  describe 'import_existing_permission_sets' do
+    include_context(
+      'rake',
+      task_path: path,
+      task_name: 'solidus:import_existing_permission_sets'
+    )
+
+    it 'creates permission sets' do
+      expect(Spree::PermissionSet.pluck(:set)).to eq([])
+
+      task.invoke
+
+      expect(Spree::PermissionSet.pluck(:set)).to eq(Spree::PermissionSets::Base.subclasses.map(&:to_s))
+    end
+
+    context 'when there is a custom role' do
+      let(:role_name) { :customer_service }
+      let(:permissions) { ['Spree::PermissionSets::OrderDisplay', 'Spree::PermissionSets::UserDisplay', 'Spree::PermissionSets::ProductDisplay'] }
+
+      before do
+        roles = Spree::RoleConfiguration.new.tap do |role|
+          role.assign_permissions :default, ['Spree::PermissionSets::DefaultCustomer']
+          role.assign_permissions :admin, ['Spree::PermissionSets::SuperUser']
+          role.assign_permissions role_name, permissions
+        end
+
+        allow_any_instance_of(Spree::AppConfiguration).to receive(:roles).and_return(roles)
+      end
+
+      it 'creates the new role with permissions' do
+        expect(Spree::Role.find_by(name: role_name.to_s)).not_to be_present
+
+        task.invoke
+
+        role = Spree::Role.find_by(name: role_name.to_s)
+        expect(role).to be_present
+        expect(role.permission_sets.pluck(:set)).to match_array(permissions)
+      end
+    end
+
+    context 'when permission set is not found' do
+      it 'prints out the missing permission set' do
+        allow(Spree::PermissionSet).to receive(:find_by).and_return(nil)
+
+        expect { task.invoke }.to output(a_string_including('Spree::PermissionSets::DefaultCustomer')).to_stdout
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This rake task creates `Spree::PermissionSet` records for each existing permission set subclass in `Spree::PermissionSets::*`, and `Spree::RolePermission` records for each role's associated permission sets. 
(It is designed to work with both new installations and existing Solidus stores that have custom roles and permissions).

### Usage

```
bin/rails solidus:import_existing_permission_sets
